### PR TITLE
feat: rework variables and add more functionality

### DIFF
--- a/.github/actions/integ-tests/action.yml
+++ b/.github/actions/integ-tests/action.yml
@@ -4,9 +4,6 @@ inputs:
     registry:
         description: 'The Docker registry to push images to'
         required: true
-    project:
-        description: 'The project name in the Docker registry'
-        required: true
     image:
         description: 'The Docker image name'
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,7 @@ jobs:
               uses: ./.github/actions/integ-tests
               with:
                   registry: 'your-registry.example.com'
-                  project: 'your-project'
-                  image: 'your-image'
+                  image: 'your-project/your-image'
                   tags: '["latest", "v1"]'
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ plugins:
     - '@semantic-release/git'
     - - '@bpgeck/semantic-release-kaniko'
       - registry: 'registry.example.com'
-        project: 'my-project'
-        image: 'my-image'
+        image: 'my-project/my-image'
         tags:
             - '${version}'
             - 'latest'
@@ -74,8 +73,7 @@ plugins:
             "@bpgeck/semantic-release-kaniko",
             {
                 "registry": "registry.example.com",
-                "project": "my-project",
-                "image": "my-image",
+                "image": "my-project/my-image",
                 "tags": ["${version}", "latest"],
                 "username": "${DOCKER_USERNAME}",
                 "password": "${DOCKER_PASSWORD}",
@@ -98,8 +96,7 @@ module.exports = {
             '@bpgeck/semantic-release-kaniko',
             {
                 registry: 'registry.example.com',
-                project: 'my-project',
-                image: 'my-image',
+                image: 'my-project/my-image',
                 tags: ['${version}', 'latest'],
                 username: process.env.DOCKER_USERNAME,
                 password: process.env.DOCKER_PASSWORD,
@@ -207,7 +204,6 @@ workflows:
 | Option   | Description                                                                                                                          |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | registry | The Docker registry to push images to.                                                                                               |
-| project  | The project name in the Docker registry.                                                                                             |
 | image    | The Docker image name.                                                                                                               |
 | tags     | An array of tags to apply to the Docker image.                                                                                       |
 | username | (Optional) The username for Docker registry authentication.                                                                          |

--- a/README.md
+++ b/README.md
@@ -201,14 +201,21 @@ workflows:
 
 ## Configuration
 
-| Option   | Description                                                                                                                          |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| registry | The Docker registry to push images to.                                                                                               |
-| image    | The Docker image name.                                                                                                               |
-| tags     | An array of tags to apply to the Docker image.                                                                                       |
-| username | (Optional) The username for Docker registry authentication.                                                                          |
-| password | (Optional) The password for Docker registry authentication.                                                                          |
-| insecure | (Optional) Set to `true` to skip Docker registry TLS verification. This should be used only for testing or development environments. |
+| .releaserc | env var         | Description                                                                                                                          |
+| ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| registry   | REGISTRY        | The Docker registry to push images to.                                                                                               |
+| image      | IMAGE           | The Docker image name.                                                                                                               |
+| tags       | TAGS            | An array of tags to apply to the Docker image. For env var, a comma-separated list of tags to apply to the image.                    |
+| dockerfile | DOCKERFILE      | (Optional) The path to the Dockerfile to be built into a Docker image. Defaults to 'Dockerfile'                                      |
+| username   | DOCKER_USERNAME | (Optional) The username for Docker registry authentication.                                                                          |
+| password   | DOCKER_PASSWORD | (Optional) The password for Docker registry authentication.                                                                          |
+| insecure   | INSECURE        | (Optional) Set to `true` to skip Docker registry TLS verification. This should be used only for testing or development environments. |
+| target     | TARGET          | (Optional) The target build stage to build in a multi-stage Dockerfile.                                                              |
+| cache      | CACHE           | (Optional) Set to `true` to enable caching in Kaniko.                                                                                |
+| cacheTTL   | CACHE_TTL       | (Optional) TTL for cached layers. Cache must be set to `true`. Defaults to '24h' if cache is enabled.                                |
+| kanikoDir  | KANIKO_DIR      | (Optional) Specify the directory where Kaniko will store its intermediate files, such as the image layers, during the build process  |
+
+.releaserc configuration takes precedence over environment variables if both are provided.
 
 ## Contributing
 

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -27,6 +27,7 @@ function parseConfig(pluginConfig) {
         target: pluginConfig.target || process.env.TARGET,
         cache: toBoolean(pluginConfig.cache || process.env.CACHE),
         cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h',
+        kanikoDir: pluginConfig.kanikoDir || process.env.KANIKO_DIR,
     };
 }
 

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -16,8 +16,13 @@ function toBoolean(value) {
  * @returns {Object} - The parsed configuration.
  */
 function parseConfig(pluginConfig) {
+
+    const project = pluginConfig.project || process.env.PROJECT;
+    const image = pluginConfig.image || process.env.IMAGE;
+    const dockerImage = project ? `${project}/${image}` : image || pluginConfig.dockerImage || process.env.DOCKER_IMAGE;    
+
     return {
-        dockerImage: pluginConfig.dockerImage || process.env.DOCKER_IMAGE,
+        dockerImage,
         tags: pluginConfig.tags || (process.env.TAGS ? process.env.TAGS.split(',') : []),
         dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE || 'Dockerfile',
         registry: pluginConfig.registry || process.env.REGISTRY,
@@ -26,7 +31,7 @@ function parseConfig(pluginConfig) {
         insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
         target: pluginConfig.target || process.env.TARGET,
         cache: toBoolean(pluginConfig.cache || process.env.CACHE),
-        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h', // Default cache TTL to 24h
+        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h',
     };
 }
 

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,0 +1,33 @@
+/**
+ * Utility function to convert environment variable string to boolean.
+ * @param {string} value - The environment variable value.
+ * @returns {boolean} - The boolean representation of the value.
+ */
+function toBoolean(value) {
+    if (typeof value === 'string') {
+        return value.toLowerCase() === 'true' || value === '1';
+    }
+    return Boolean(value);
+}
+
+/**
+ * Parses the configuration from pluginConfig and environment variables.
+ * @param {Object} pluginConfig - The plugin configuration.
+ * @returns {Object} - The parsed configuration.
+ */
+function parseConfig(pluginConfig) {
+    return {
+        dockerImage: pluginConfig.dockerImage || process.env.DOCKER_IMAGE,
+        tags: pluginConfig.tags || (process.env.TAGS ? process.env.TAGS.split(',') : []),
+        dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE || 'Dockerfile',
+        registry: pluginConfig.registry || process.env.REGISTRY,
+        username: pluginConfig.username || process.env.DOCKER_USERNAME,
+        password: pluginConfig.password || process.env.DOCKER_PASSWORD,
+        insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
+        target: pluginConfig.target || process.env.TARGET,
+        cache: toBoolean(pluginConfig.cache || process.env.CACHE),
+        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h', // Default cache TTL to 24h
+    };
+}
+
+export { toBoolean, parseConfig };

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -16,13 +16,8 @@ function toBoolean(value) {
  * @returns {Object} - The parsed configuration.
  */
 function parseConfig(pluginConfig) {
-
-    const project = pluginConfig.project || process.env.PROJECT;
-    const image = pluginConfig.image || process.env.IMAGE;
-    const dockerImage = project ? `${project}/${image}` : image || pluginConfig.dockerImage || process.env.DOCKER_IMAGE;    
-
     return {
-        dockerImage,
+        image: pluginConfig.image || process.env.IMAGE,
         tags: pluginConfig.tags || (process.env.TAGS ? process.env.TAGS.split(',') : []),
         dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE || 'Dockerfile',
         registry: pluginConfig.registry || process.env.REGISTRY,

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -2,14 +2,26 @@ import { execa } from 'execa';
 
 async function publish(pluginConfig, context) {
     const { logger, nextRelease } = context;
-    const { project, image, tags, dockerfile, registry, username, password, insecure } =
-        pluginConfig;
 
-    const dockerfilePath = dockerfile || 'Dockerfile';
-    const fullImageName = `${project}/${image}`;
+    // Read configuration from pluginConfig or environment variables
+    const image = pluginConfig.image || process.env.DOCKER_IMAGE;
+    const tags = pluginConfig.tags || (process.env.DOCKER_TAGS ? process.env.DOCKER_TAGS.split(',') : []);
+    const dockerfile = pluginConfig.dockerfile || process.env.DOCKER_FILE || 'Dockerfile';
+    const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
+    const username = pluginConfig.username || process.env.DOCKER_USERNAME;
+    const password = pluginConfig.password || process.env.DOCKER_PASSWORD;
+    const insecure = pluginConfig.insecure || process.env.DOCKER_INSECURE === 'true';
+    const target = pluginConfig.target || process.env.DOCKER_TARGET; // Optional build target
+    const cache = pluginConfig.cache || process.env.DOCKER_CACHE === 'false';
+    const cacheTTL = pluginConfig.cache_ttl || process.env.DOCKER_CACHE_TTL || '24h'; // Default cache TTL to 24h
+    const runCleanup = pluginConfig.run_cleanup || process.env.KANIKO_RUN_CLEANUP === 'false';
+
+    if (!image || !registry) {
+        throw new Error('Both dockerImage and registry must be specified.');
+    }
 
     for (const tag of tags) {
-        const tagName = `${fullImageName}:${tag === '${version}' ? nextRelease.version : tag}`;
+        const tagName = `${dockerImage}:${tag === '${version}' ? nextRelease.version : tag}`;
         const fullUri = `${registry}/${tagName}`;
 
         logger.log(`Building and pushing Docker image: ${fullUri}`);
@@ -17,14 +29,18 @@ async function publish(pluginConfig, context) {
         try {
             const kanikoArgs = [
                 '--dockerfile',
-                dockerfilePath,
+                dockerfile,
                 '--context',
                 '.',
                 '--destination',
-                fullUri,
+                fullUri
             ];
 
-            if (insecure) kanikoArgs.push('--insecure');
+            if (target) kanikoArgs.push('--target', target); // Add target if specified
+            if (insecure) kanikoArgs.push('--insecure');            
+            if (cache) kanikoArgs.push('--cache=true'); // Enable cache if specified
+            if (cacheTTL) kanikoArgs.push('--cache-ttl', cacheTTL); // Set cache TTL if specified
+            if (runCleanup) kanikoArgs.push('--cleanup');
 
             const env = {};
             if (username) env.DOCKER_USERNAME = username;

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import { parseConfig } from './config';
+import { parseConfig } from './config.mjs';
 
 async function publish(pluginConfig, context) {
     const { logger, nextRelease } = context;
@@ -24,11 +24,11 @@ async function publish(pluginConfig, context) {
                 '--context',
                 '.',
                 '--destination',
-                fullUri
+                fullUri,
             ];
 
             if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
-            if (config.insecure) kanikoArgs.push('--insecure');            
+            if (config.insecure) kanikoArgs.push('--insecure');
             if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
             if (config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
             if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -17,11 +17,11 @@ async function publish(pluginConfig, context) {
     const kanikoDir = pluginConfig.kanikoDir || process.env.KANIKO_DIR;
 
     if (!image || !registry) {
-        throw new Error('Both dockerImage and registry must be specified.');
+        throw new Error('Both image and registry must be specified.');
     }
 
     for (const tag of tags) {
-        const tagName = `${dockerImage}:${tag === '${version}' ? nextRelease.version : tag}`;
+        const tagName = `${image}:${tag === '${version}' ? nextRelease.version : tag}`;
         const fullUri = `${registry}/${tagName}`;
 
         logger.log(`Building and pushing Docker image: ${fullUri}`);

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -29,7 +29,7 @@ async function publish(pluginConfig, context) {
 
             if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
             if (config.insecure) kanikoArgs.push('--insecure');            
-            if (config.cache) kanikoArgs.push('--cache=true'); // Enable cache if specified
+            if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
             if (config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
             if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
 

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -1,5 +1,17 @@
 import { execa } from 'execa';
 
+/**
+ * Utility function to convert environment variable string to boolean.
+ * @param {string} value - The environment variable value.
+ * @returns {boolean} - The boolean representation of the value.
+ */
+function toBoolean(value) {
+    if (typeof value === 'string') {
+        return value.toLowerCase() === 'true' || value === '1';
+    }
+    return Boolean(value);
+}
+
 async function publish(pluginConfig, context) {
     const { logger, nextRelease } = context;
 
@@ -10,9 +22,9 @@ async function publish(pluginConfig, context) {
     const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
     const username = pluginConfig.username || process.env.DOCKER_USERNAME;
     const password = pluginConfig.password || process.env.DOCKER_PASSWORD;
-    const insecure = pluginConfig.insecure || process.env.DOCKER_INSECURE === 'false';
+    const insecure = toBoolean(pluginConfig.insecure || process.env.DOCKER_INSECURE);
     const target = pluginConfig.target || process.env.DOCKER_TARGET;
-    const cache = pluginConfig.cache || process.env.DOCKER_CACHE === 'false';
+    const cache = toBoolean(pluginConfig.cache || process.env.DOCKER_CACHE);
     const cacheTTL = pluginConfig.cacheTtl || process.env.DOCKER_CACHE_TTL;
     const kanikoDir = pluginConfig.kanikoDir || process.env.KANIKO_DIR;
 

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -1,62 +1,41 @@
 import { execa } from 'execa';
-
-/**
- * Utility function to convert environment variable string to boolean.
- * @param {string} value - The environment variable value.
- * @returns {boolean} - The boolean representation of the value.
- */
-function toBoolean(value) {
-    if (typeof value === 'string') {
-        return value.toLowerCase() === 'true' || value === '1';
-    }
-    return Boolean(value);
-}
+import { parseConfig } from './config';
 
 async function publish(pluginConfig, context) {
     const { logger, nextRelease } = context;
 
-    // Read configuration from pluginConfig or environment variables
-    const image = pluginConfig.image || process.env.DOCKER_IMAGE;
-    const tags = pluginConfig.tags || (process.env.DOCKER_TAGS ? process.env.DOCKER_TAGS.split(',') : []);
-    const dockerfile = pluginConfig.dockerfile || process.env.DOCKER_FILE || 'Dockerfile';
-    const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
-    const username = pluginConfig.username || process.env.DOCKER_USERNAME;
-    const password = pluginConfig.password || process.env.DOCKER_PASSWORD;
-    const insecure = toBoolean(pluginConfig.insecure || process.env.DOCKER_INSECURE);
-    const target = pluginConfig.target || process.env.DOCKER_TARGET;
-    const cache = toBoolean(pluginConfig.cache || process.env.DOCKER_CACHE);
-    const cacheTTL = pluginConfig.cacheTtl || process.env.DOCKER_CACHE_TTL;
-    const kanikoDir = pluginConfig.kanikoDir || process.env.KANIKO_DIR;
+    // Parse configuration
+    const config = parseConfig(pluginConfig);
 
-    if (!image || !registry) {
+    if (!config.image || !config.registry) {
         throw new Error('Both image and registry must be specified.');
     }
 
-    for (const tag of tags) {
-        const tagName = `${image}:${tag === '${version}' ? nextRelease.version : tag}`;
-        const fullUri = `${registry}/${tagName}`;
+    for (const tag of config.tags) {
+        const tagName = `${config.image}:${tag === '${version}' ? nextRelease.version : tag}`;
+        const fullUri = `${config.registry}/${tagName}`;
 
         logger.log(`Building and pushing Docker image: ${fullUri}`);
 
         try {
             const kanikoArgs = [
                 '--dockerfile',
-                dockerfile,
+                config.dockerfile,
                 '--context',
                 '.',
                 '--destination',
                 fullUri
             ];
 
-            if (target) kanikoArgs.push('--target', target); // Add target if specified
-            if (insecure) kanikoArgs.push('--insecure');            
-            if (cache) kanikoArgs.push('--cache=true'); // Enable cache if specified
-            if (cacheTTL) kanikoArgs.push('--cache-ttl', cacheTTL); // Set cache TTL if specified
-            if (kanikoDir) kanikoArgs.push('--kaniko-dir', kanikoDir); // Set an alternative staging folder for Kaniko
+            if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
+            if (config.insecure) kanikoArgs.push('--insecure');            
+            if (config.cache) kanikoArgs.push('--cache=true'); // Enable cache if specified
+            if (config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
+            if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
 
             const env = {};
-            if (username) env.DOCKER_USERNAME = username;
-            if (password) env.DOCKER_PASSWORD = password;
+            if (config.username) env.DOCKER_USERNAME = config.username;
+            if (config.password) env.DOCKER_PASSWORD = config.password;
 
             await execa('/kaniko/executor', kanikoArgs, { env });
             logger.log(`Successfully built and pushed image: ${fullUri}`);

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -10,11 +10,11 @@ async function publish(pluginConfig, context) {
     const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
     const username = pluginConfig.username || process.env.DOCKER_USERNAME;
     const password = pluginConfig.password || process.env.DOCKER_PASSWORD;
-    const insecure = pluginConfig.insecure || process.env.DOCKER_INSECURE === 'true';
+    const insecure = pluginConfig.insecure || process.env.DOCKER_INSECURE === 'false';
     const target = pluginConfig.target || process.env.DOCKER_TARGET; // Optional build target
     const cache = pluginConfig.cache || process.env.DOCKER_CACHE === 'false';
-    const cacheTTL = pluginConfig.cache_ttl || process.env.DOCKER_CACHE_TTL || '24h'; // Default cache TTL to 24h
-    const runCleanup = pluginConfig.run_cleanup || process.env.KANIKO_RUN_CLEANUP === 'false';
+    const cacheTTL = pluginConfig.cacheTtl || process.env.DOCKER_CACHE_TTL || '24h'; // Default cache TTL to 24h    
+    const kanikoDir = pluginConfig.kanikoDir || process.env.KANIKO_DIR;
 
     if (!image || !registry) {
         throw new Error('Both dockerImage and registry must be specified.');
@@ -40,7 +40,7 @@ async function publish(pluginConfig, context) {
             if (insecure) kanikoArgs.push('--insecure');            
             if (cache) kanikoArgs.push('--cache=true'); // Enable cache if specified
             if (cacheTTL) kanikoArgs.push('--cache-ttl', cacheTTL); // Set cache TTL if specified
-            if (runCleanup) kanikoArgs.push('--cleanup');
+            if (kanikoDir) kanikoArgs.push('--kaniko-dir', kanikoDir); // Set an alternative staging folder for Kaniko
 
             const env = {};
             if (username) env.DOCKER_USERNAME = username;

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -28,9 +28,9 @@ async function publish(pluginConfig, context) {
             ];
 
             if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
-            if (config.insecure) kanikoArgs.push('--insecure');
+            if (config.insecure) kanikoArgs.push('--insecure'); // Set to insecure mode if specified
             if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
-            if (config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
+            if (config.cache && config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
             if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
 
             const env = {};

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -11,9 +11,9 @@ async function publish(pluginConfig, context) {
     const username = pluginConfig.username || process.env.DOCKER_USERNAME;
     const password = pluginConfig.password || process.env.DOCKER_PASSWORD;
     const insecure = pluginConfig.insecure || process.env.DOCKER_INSECURE === 'false';
-    const target = pluginConfig.target || process.env.DOCKER_TARGET; // Optional build target
+    const target = pluginConfig.target || process.env.DOCKER_TARGET;
     const cache = pluginConfig.cache || process.env.DOCKER_CACHE === 'false';
-    const cacheTTL = pluginConfig.cacheTtl || process.env.DOCKER_CACHE_TTL || '24h'; // Default cache TTL to 24h    
+    const cacheTTL = pluginConfig.cacheTtl || process.env.DOCKER_CACHE_TTL;
     const kanikoDir = pluginConfig.kanikoDir || process.env.KANIKO_DIR;
 
     if (!image || !registry) {

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -1,7 +1,7 @@
 import SemanticReleaseError from '@semantic-release/error';
 import { execa } from 'execa';
 import { promises as fs } from 'fs';
-import { parseConfig } from './config';
+import { parseConfig } from './config.mjs';
 
 // Error messages
 const ERRORS = {
@@ -36,7 +36,7 @@ async function verifyConditions(pluginConfig, context) {
     if (!config.registry) {
         throw new SemanticReleaseError(ERRORS.MISSING_REGISTRY, 'EMISSINGREGISTRY');
     }
-    if (!config.dockerImage) {
+    if (!config.image) {
         throw new SemanticReleaseError(ERRORS.MISSING_IMAGE, 'EMISSINGIMAGE');
     }
     if (!Array.isArray(config.tags) || config.tags.length === 0) {

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -1,6 +1,7 @@
 import SemanticReleaseError from '@semantic-release/error';
 import { execa } from 'execa';
 import { promises as fs } from 'fs';
+import { parseConfig } from './config';
 
 // Error messages
 const ERRORS = {
@@ -28,30 +29,27 @@ async function verifyConditions(pluginConfig, context) {
         throw new SemanticReleaseError(ERRORS.MISSING_KANIKO, 'EKANIKOOMISSING');
     }
 
-    // Retrieve configuration from pluginConfig or environment variables
-    const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
-    const dockerImage = pluginConfig.dockerImage || process.env.DOCKER_IMAGE;
-    const tags = pluginConfig.tags || (process.env.DOCKER_TAGS ? process.env.DOCKER_TAGS.split(',') : []);
-    const dockerfilePath = pluginConfig.dockerfile || process.env.DOCKER_FILE || 'Dockerfile';
+    // Parse configuration
+    const config = parseConfig(pluginConfig);
 
     // Verify required configuration fields
-    if (!registry) {
+    if (!config.registry) {
         throw new SemanticReleaseError(ERRORS.MISSING_REGISTRY, 'EMISSINGREGISTRY');
     }
-    if (!dockerImage) {
+    if (!config.dockerImage) {
         throw new SemanticReleaseError(ERRORS.MISSING_IMAGE, 'EMISSINGIMAGE');
     }
-    if (!Array.isArray(tags) || tags.length === 0) {
+    if (!Array.isArray(config.tags) || config.tags.length === 0) {
         throw new SemanticReleaseError(ERRORS.MISSING_TAGS, 'EMISSINGTAGS');
     }
 
     // Check if Dockerfile exists
     try {
-        await fs.access(dockerfilePath);
-        logger.info(`Dockerfile found at ${dockerfilePath}`);
+        await fs.access(config.dockerfile);
+        logger.info(`Dockerfile found at ${config.dockerfile}`);
     } catch (_error) {
         throw new SemanticReleaseError(
-            ERRORS.DOCKERFILE_NOT_FOUND(dockerfilePath),
+            ERRORS.DOCKERFILE_NOT_FOUND(config.dockerfile),
             'EDOCKERFILENOTFOUND'
         );
     }

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -5,10 +5,9 @@ import { promises as fs } from 'fs';
 // Error messages
 const ERRORS = {
     MISSING_KANIKO: 'Kaniko is not installed or not in PATH',
-    MISSING_REGISTRY: 'Missing Docker registry in plugin configuration',
-    MISSING_PROJECT: 'Missing Docker project name in plugin configuration',
-    MISSING_IMAGE: 'Missing Docker image name in plugin configuration',
-    MISSING_TAGS: 'Missing image tags in plugin configuration',
+    MISSING_REGISTRY: 'Missing Docker registry in configuration',
+    MISSING_IMAGE: 'Missing Docker image name in configuration',
+    MISSING_TAGS: 'Missing image tags in configuration',
     DOCKERFILE_NOT_FOUND: path => `Dockerfile not found at ${path}`,
     REGISTRY_AUTH: 'Not authenticated with Docker registry',
 };
@@ -29,16 +28,17 @@ async function verifyConditions(pluginConfig, context) {
         throw new SemanticReleaseError(ERRORS.MISSING_KANIKO, 'EKANIKOOMISSING');
     }
 
-    const { registry, project, image, tags } = pluginConfig;
+    // Retrieve configuration from pluginConfig or environment variables
+    const registry = pluginConfig.registry || process.env.DOCKER_REGISTRY;
+    const dockerImage = pluginConfig.dockerImage || process.env.DOCKER_IMAGE;
+    const tags = pluginConfig.tags || (process.env.DOCKER_TAGS ? process.env.DOCKER_TAGS.split(',') : []);
+    const dockerfilePath = pluginConfig.dockerfile || process.env.DOCKER_FILE || 'Dockerfile';
 
     // Verify required configuration fields
     if (!registry) {
         throw new SemanticReleaseError(ERRORS.MISSING_REGISTRY, 'EMISSINGREGISTRY');
     }
-    if (!project) {
-        throw new SemanticReleaseError(ERRORS.MISSING_PROJECT, 'EMISSINGPROJECT');
-    }
-    if (!image) {
+    if (!dockerImage) {
         throw new SemanticReleaseError(ERRORS.MISSING_IMAGE, 'EMISSINGIMAGE');
     }
     if (!Array.isArray(tags) || tags.length === 0) {
@@ -46,7 +46,6 @@ async function verifyConditions(pluginConfig, context) {
     }
 
     // Check if Dockerfile exists
-    const dockerfilePath = pluginConfig.dockerfile || 'Dockerfile';
     try {
         await fs.access(dockerfilePath);
         logger.info(`Dockerfile found at ${dockerfilePath}`);

--- a/tst/integ/preparePublish.test.js
+++ b/tst/integ/preparePublish.test.js
@@ -20,8 +20,7 @@ describe('Prepare and Publish', function () {
 
         pluginConfig = {
             registry: 'mock-registry:5000',
-            project: 'my-project',
-            image: 'my-image',
+            image: 'my-project/my-image',
             tags: ['${version}', 'latest'],
             dockerfile: 'tst/integ/resources/test.Dockerfile',
             username: 'test-user',

--- a/tst/integ/verifyConditions.test.js
+++ b/tst/integ/verifyConditions.test.js
@@ -16,6 +16,16 @@ const context = {
 describe('Verify Conditions', function () {
     this.timeout(20000);
 
+    let originalEnv;
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
     it('should fail if Dockerfile is missing', async () => {
         const invalidConfig = { ...validConfig, dockerfile: 'NonExistentDockerfile' };
         await assert.rejects(verifyConditions(invalidConfig, context), error => {
@@ -50,5 +60,15 @@ describe('Verify Conditions', function () {
             assert.strictEqual(error.code, 'EMISSINGTAGS');
             return true;
         });
+    });
+
+    it('should use environment variables when config is not provided', async () => {
+        process.env.IMAGE = 'env-test-image';
+        process.env.TAGS = 'latest,${version}';
+        process.env.REGISTRY = 'env-registry:5000';
+        process.env.DOCKERFILE = 'tst/integ/resources/test.Dockerfile';
+
+        const emptyConfig = {};
+        await verifyConditions(emptyConfig, { logger: console });
     });
 });

--- a/tst/integ/verifyConditions.test.js
+++ b/tst/integ/verifyConditions.test.js
@@ -3,9 +3,8 @@ import assert from 'assert';
 import SemanticReleaseError from '@semantic-release/error';
 
 const validConfig = {
-    project: 'test-project',
-    image: 'test-image',
-    tags: ['latest', 'v1.0.0'],
+    image: 'test-project/test-image',
+    tags: ['latest', '${version}'],
     registry: 'mock-registry:5000',
     dockerfile: 'Dockerfile',
 };
@@ -19,61 +18,37 @@ describe('Verify Conditions', function () {
 
     it('should fail if Dockerfile is missing', async () => {
         const invalidConfig = { ...validConfig, dockerfile: 'NonExistentDockerfile' };
-
-        try {
-            await verifyConditions(invalidConfig, context);
-            assert.fail('Expected an error due to missing Dockerfile');
-        } catch (error) {
+        await assert.rejects(verifyConditions(invalidConfig, context), error => {
             assert(error instanceof SemanticReleaseError);
             assert.strictEqual(error.code, 'EDOCKERFILENOTFOUND');
-        }
+            return true;
+        });
     });
 
     it('should fail if registry is missing in configuration', async () => {
         const invalidConfig = { ...validConfig, registry: null };
-
-        try {
-            await verifyConditions(invalidConfig, context);
-            assert.fail('Expected an error due to missing registry');
-        } catch (error) {
+        await assert.rejects(verifyConditions(invalidConfig, context), error => {
             assert(error instanceof SemanticReleaseError);
             assert.strictEqual(error.code, 'EMISSINGREGISTRY');
-        }
-    });
-
-    it('should fail if project is missing in configuration', async () => {
-        const invalidConfig = { ...validConfig, project: null };
-
-        try {
-            await verifyConditions(invalidConfig, context);
-            assert.fail('Expected an error due to missing project name');
-        } catch (error) {
-            assert(error instanceof SemanticReleaseError);
-            assert.strictEqual(error.code, 'EMISSINGPROJECT');
-        }
+            return true;
+        });
     });
 
     it('should fail if image is missing in configuration', async () => {
         const invalidConfig = { ...validConfig, image: null };
-
-        try {
-            await verifyConditions(invalidConfig, context);
-            assert.fail('Expected an error due to missing image name');
-        } catch (error) {
+        await assert.rejects(verifyConditions(invalidConfig, context), error => {
             assert(error instanceof SemanticReleaseError);
             assert.strictEqual(error.code, 'EMISSINGIMAGE');
-        }
+            return true;
+        });
     });
 
     it('should fail if tags are missing in configuration', async () => {
         const invalidConfig = { ...validConfig, tags: [] };
-
-        try {
-            await verifyConditions(invalidConfig, context);
-            assert.fail('Expected an error due to missing tags');
-        } catch (error) {
+        await assert.rejects(verifyConditions(invalidConfig, context), error => {
             assert(error instanceof SemanticReleaseError);
             assert.strictEqual(error.code, 'EMISSINGTAGS');
-        }
+            return true;
+        });
     });
 });


### PR DESCRIPTION
- Reworked the parameters, they can either be set in the plugin or via env. This makes it easier to configure in CI
  - Added support for `--target` to target a specific stage of the container to build
  - Added support for `--cache` and `--cache-ttl` to use transparant Kaniko cache
  - Added support for providing an alternative Kaniko directory (as it breaks building images that contain Kaniko in `/kaniko/executor`)
  - Simplified the required parameters for creating the registry URI, only the registry + image is now used, `project` seemed redundant

Tested on GitLab using these variables:

```yaml
  variables:
    DOCKER_IMAGE: "${CI_PROJECT_PATH}"
    DOCKER_REGISTRY: "${CI_REGISTRY}"
    DOCKER_USERNAME: "semantic-release"
    DOCKER_PASSWORD: "${GITLAB_TOKEN}"
    DOCKER_INSECURE: false
    DOCKER_CACHE: true
    DOCKER_CACHE_TTL: "48h"
    KANIKO_DIR: /tmp/kaniko
```

`${CI_PROJECT_PATH}` and `${CI_REGISTRY}` are default built in parameters, `${GITLAB_TOKEN}` is one I defined myself.