### PR TITLE
feat: tag multiple images in single run

### DIFF
--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -11,38 +11,40 @@ async function publish(pluginConfig, context) {
         throw new Error('Both image and registry must be specified.');
     }
 
+    const destinations = [];
+
     for (const tag of config.tags) {
         const tagName = `${config.image}:${tag === '${version}' ? nextRelease.version : tag}`;
         const fullUri = `${config.registry}/${tagName}`;
+        destinations.push(fullUri);
+    }
 
-        logger.log(`Building and pushing Docker image: ${fullUri}`);
+    logger.log(`Building and pushing Docker image with the following destinations: ${destinations.join(', ')}`);
 
-        try {
-            const kanikoArgs = [
-                '--dockerfile',
-                config.dockerfile,
-                '--context',
-                '.',
-                '--destination',
-                fullUri,
-            ];
+    try {
+        const kanikoArgs = [
+            '--dockerfile',
+            config.dockerfile,
+            '--context',
+            '.',
+            ...destinations.flatMap(destination => ['--destination', destination])
+        ];
 
-            if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
-            if (config.insecure) kanikoArgs.push('--insecure'); // Set to insecure mode if specified
-            if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
-            if (config.cache && config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
-            if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
+        if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
+        if (config.insecure) kanikoArgs.push('--insecure'); // Set to insecure mode if specified
+        if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
+        if (config.cache && config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
+        if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
 
-            const env = {};
-            if (config.username) env.DOCKER_USERNAME = config.username;
-            if (config.password) env.DOCKER_PASSWORD = config.password;
+        const env = {};
+        if (config.username) env.DOCKER_USERNAME = config.username;
+        if (config.password) env.DOCKER_PASSWORD = config.password;
 
-            await execa('/kaniko/executor', kanikoArgs, { env });
-            logger.log(`Successfully built and pushed image: ${fullUri}`);
-        } catch (error) {
-            logger.error(`Failed to build and push image: ${fullUri}`);
-            throw error;
-        }
+        await execa('/kaniko/executor', kanikoArgs, { env });
+        logger.log(`Successfully built and pushed images: ${destinations.join(', ')}`);
+    } catch (error) {
+        logger.error(`Failed to build and push images: ${destinations.join(', ')}`);
+        throw error;
     }
 
     logger.log('Docker image publishing complete.');

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -11,13 +11,10 @@ async function publish(pluginConfig, context) {
         throw new Error('Both image and registry must be specified.');
     }
 
-    const destinations = [];
-
-    for (const tag of config.tags) {
+    const destinations = config.tags.map(tag => {
         const tagName = `${config.image}:${tag === '${version}' ? nextRelease.version : tag}`;
-        const fullUri = `${config.registry}/${tagName}`;
-        destinations.push(fullUri);
-    }
+        return `${config.registry}/${tagName}`;
+    });
 
     logger.log(`Building and pushing Docker image with the following destinations: ${destinations.join(', ')}`);
 


### PR DESCRIPTION
In the current implementation, Kaniko is executed separately for each individual tag, resulting in multiple runs. For example, it runs once for `1.0.0` and again for `latest`.

Kaniko, however, supports the use of multiple `--destination` flags, enabling us to build the image once and tag it with multiple versions in a single execution. 
This change significantly enhances performance when multiple tags are involved, and also reduces the risk of inconsistencies such as successfully building the `1.0.0` tag but encountering failures with the `latest` tag.

This optimization should streamline the build process and improve reliability.