### PR TITLE
feat: add argument for providing args to kaniko

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ workflows:
 | cache      | CACHE           | (Optional) Set to `true` to enable caching in Kaniko.                                                                                |
 | cacheTTL   | CACHE_TTL       | (Optional) TTL for cached layers. Cache must be set to `true`. Defaults to '24h' if cache is enabled.                                |
 | kanikoDir  | KANIKO_DIR      | (Optional) Specify the directory where Kaniko will store its intermediate files, such as the image layers, during the build process  |
+| kanikoArgs | KANIKO_ARGS     | (Optional) Additional arguments to provide to the Kaniko binary (e.g. `--ignore-var-run`)                                            |
 
 .releaserc configuration takes precedence over environment variables if both are provided.
 

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -28,6 +28,7 @@ function parseConfig(pluginConfig) {
         cache: toBoolean(pluginConfig.cache || process.env.CACHE),
         cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h',
         kanikoDir: pluginConfig.kanikoDir || process.env.KANIKO_DIR,
+        kanikoArgs: pluginConfig.kanikoArgs || (process.env.KANIKO_ARGS ? process.env.KANIKO_ARGS.split(' ') : []),
     };
 }
 

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -33,6 +33,11 @@ async function publish(pluginConfig, context) {
         if (config.cache && config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
         if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
 
+        // Append user-defined Kaniko arguments
+        if (config.kanikoArgs) {
+            kanikoArgs.push(...config.kanikoArgs);
+        }
+
         const env = {};
         if (config.username) env.DOCKER_USERNAME = config.username;
         if (config.password) env.DOCKER_PASSWORD = config.password;


### PR DESCRIPTION
This introduces the optional variable `kanikoArgs` (or `KANIKO_ARGS` for env) to allow to add arguments to Kaniko, e.g. `--ignore-var-run` which may be desired in some situations. 