### PR TITLE
breaking: Modifying inputs to support all kaniko parameters

### DIFF
--- a/.github/actions/integ-tests/Dockerfile
+++ b/.github/actions/integ-tests/Dockerfile
@@ -17,5 +17,5 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set the entrypoint
-ARG INTEG_TEST_FILE
-ENTRYPOINT ["/entrypoint.sh", "$INTEG_TEST_FILE"]
+ARG testFile
+ENTRYPOINT ["/entrypoint.sh", "$testFile"]

--- a/.github/actions/integ-tests/Dockerfile
+++ b/.github/actions/integ-tests/Dockerfile
@@ -18,4 +18,6 @@ RUN chmod +x /entrypoint.sh
 
 # Set the entrypoint
 ARG testFile
-ENTRYPOINT ["/entrypoint.sh", $testFile]
+ENV TEST_FILE=${testFile}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/integ-tests/Dockerfile
+++ b/.github/actions/integ-tests/Dockerfile
@@ -17,4 +17,5 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Set the entrypoint
-ENTRYPOINT ["/entrypoint.sh"]
+ARG INTEG_TEST_FILE
+ENTRYPOINT ["/entrypoint.sh", "$INTEG_TEST_FILE"]

--- a/.github/actions/integ-tests/Dockerfile
+++ b/.github/actions/integ-tests/Dockerfile
@@ -18,4 +18,4 @@ RUN chmod +x /entrypoint.sh
 
 # Set the entrypoint
 ARG testFile
-ENTRYPOINT ["/entrypoint.sh", "$testFile"]
+ENTRYPOINT ["/entrypoint.sh", $testFile]

--- a/.github/actions/integ-tests/Dockerfile
+++ b/.github/actions/integ-tests/Dockerfile
@@ -16,8 +16,4 @@ COPY entrypoint.sh /entrypoint.sh
 # Make the script executable
 RUN chmod +x /entrypoint.sh
 
-# Set the entrypoint
-ARG testFile
-ENV TEST_FILE=${testFile}
-
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/integ-tests/action.yml
+++ b/.github/actions/integ-tests/action.yml
@@ -7,3 +7,5 @@ inputs:
 runs:
     using: 'docker'
     image: 'Dockerfile'
+    args:
+        - ${{ inputs.testFile }}

--- a/.github/actions/integ-tests/action.yml
+++ b/.github/actions/integ-tests/action.yml
@@ -1,11 +1,5 @@
 name: 'semantic-release-kaniko containerized integration tests'
 description: 'Intended for internal use only. Runs the integration tests in a containerized environment.'
-inputs:
-    testFile:
-        description: 'The integration test file'
-        required: false
 runs:
     using: 'docker'
     image: 'Dockerfile'
-    args:
-        - ${{ inputs.testFile }}

--- a/.github/actions/integ-tests/action.yml
+++ b/.github/actions/integ-tests/action.yml
@@ -1,23 +1,8 @@
 name: 'semantic-release-kaniko containerized integration tests'
 description: 'Intended for internal use only. Runs the integration tests in a containerized environment.'
 inputs:
-    registry:
-        description: 'The Docker registry to push images to'
-        required: true
-    image:
-        description: 'The Docker image name'
-        required: true
-    tags:
-        description: 'An array of tags to apply to the Docker image'
-        required: true
-    username:
-        description: 'The username for Docker registry authentication'
-        required: false
-    password:
-        description: 'The password for Docker registry authentication'
-        required: false
-    insecure:
-        description: 'Use insecure connection in integ tests'
+    testFile:
+        description: 'The integration test file'
         required: false
 runs:
     using: 'docker'

--- a/.github/actions/integ-tests/entrypoint.sh
+++ b/.github/actions/integ-tests/entrypoint.sh
@@ -19,5 +19,8 @@ npm install
 echo "Contents of GitHub Workspace:"
 ls -la $GITHUB_WORKSPACE
 
-echo "Running tests..."
-npx mocha tst/integ/**/*.test.js
+# Accept input for integ test file
+INTEG_TEST_FILE=${1:-"tst/integ/**/*.test.js"}
+
+echo "Running tests on $INTEG_TEST_FILE..."
+npx mocha $INTEG_TEST_FILE

--- a/.github/actions/integ-tests/entrypoint.sh
+++ b/.github/actions/integ-tests/entrypoint.sh
@@ -19,8 +19,5 @@ npm install
 echo "Contents of GitHub Workspace:"
 ls -la $GITHUB_WORKSPACE
 
-# Use the TEST_FILE environment variable or set a default value
-INTEG_TEST_FILE=${TEST_FILE:-"tst/integ/**/*.test.js"}
-
-echo "Running tests on $INTEG_TEST_FILE..."
-npx mocha $INTEG_TEST_FILE
+echo "Running tests on $TEST_FILE..."
+npx mocha $TEST_FILE

--- a/.github/actions/integ-tests/entrypoint.sh
+++ b/.github/actions/integ-tests/entrypoint.sh
@@ -19,8 +19,8 @@ npm install
 echo "Contents of GitHub Workspace:"
 ls -la $GITHUB_WORKSPACE
 
-# Accept input for integ test file
-INTEG_TEST_FILE=${1:-"tst/integ/**/*.test.js"}
+# Use the TEST_FILE environment variable or set a default value
+INTEG_TEST_FILE=${TEST_FILE:-"tst/integ/**/*.test.js"}
 
 echo "Running tests on $INTEG_TEST_FILE..."
 npx mocha $INTEG_TEST_FILE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Run verifyConditions tests
               uses: ./.github/actions/integ-tests
               with:
-                  integTestFile: ./.github/actions/integ-tests/tst/integ/verifyConditions.test.js
+                  testFile: ./.github/actions/integ-tests/tst/integ/verifyConditions.test.js
 
     prepare-publish-test:
         name: Prepare Publish Test
@@ -68,7 +68,7 @@ jobs:
             - name: Run preparePublish tests
               uses: ./.github/actions/integ-tests
               with:
-                  integTestFile: ./.github/actions/integ-tests/tst/integ/preparePublish.test.js
+                  testFile: ./.github/actions/integ-tests/tst/integ/preparePublish.test.js
 
     dry-run-release:
         name: Dry Run Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
             - name: Run linter
               run: npm run lint
 
-    test:
-        name: Test
+    verify-conditions-test:
+        name: Verify Conditions Test
         runs-on: ubuntu-latest
         needs: lint
         services:
@@ -42,20 +42,38 @@ jobs:
                   cp ./package.json ./.github/actions/integ-tests/package.json
                   cp ./package-lock.json ./.github/actions/integ-tests/package-lock.json
                   cp -r ./tst/ ./.github/actions/integ-tests/tst/
-            - name: Run tests
+            - name: Run verifyConditions tests
               uses: ./.github/actions/integ-tests
               with:
-                  registry: 'your-registry.example.com'
-                  image: 'your-project/your-image'
-                  tags: '["latest", "v1"]'
-                  username: ${{ secrets.DOCKER_USERNAME }}
-                  password: ${{ secrets.DOCKER_PASSWORD }}
-                  insecure: true
+                  integTestFile: ./.github/actions/integ-tests/tst/integ/verifyConditions.test.js
+
+    prepare-publish-test:
+        name: Prepare Publish Test
+        runs-on: ubuntu-latest
+        needs: lint
+        services:
+            mock-registry:
+                image: registry:2
+                ports:
+                    - 5000:5000
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Prepare build context for testing
+              run: |
+                  cp -r ./lib ./.github/actions/integ-tests/lib
+                  cp ./package.json ./.github/actions/integ-tests/package.json
+                  cp ./package-lock.json ./.github/actions/integ-tests/package-lock.json
+                  cp -r ./tst/ ./.github/actions/integ-tests/tst/
+            - name: Run preparePublish tests
+              uses: ./.github/actions/integ-tests
+              with:
+                  integTestFile: ./.github/actions/integ-tests/tst/integ/preparePublish.test.js
 
     dry-run-release:
         name: Dry Run Release
         runs-on: ubuntu-latest
-        needs: test
+        needs: [verify-conditions-test, prepare-publish-test]
         if: github.event_name == 'pull_request'
         steps:
             - name: Checkout code
@@ -75,7 +93,7 @@ jobs:
     release:
         name: Release
         runs-on: ubuntu-latest
-        needs: test
+        needs: [verify-conditions-test, prepare-publish-test]
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         steps:
             - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
                   cp -r ./tst/ ./.github/actions/integ-tests/tst/
             - name: Run verifyConditions tests
               uses: ./.github/actions/integ-tests
-              with:
-                  testFile: ./.github/actions/integ-tests/tst/integ/verifyConditions.test.js
+              env:
+                  TEST_FILE: ./.github/actions/integ-tests/tst/integ/verifyConditions.test.js
 
     prepare-publish-test:
         name: Prepare Publish Test
@@ -67,8 +67,8 @@ jobs:
                   cp -r ./tst/ ./.github/actions/integ-tests/tst/
             - name: Run preparePublish tests
               uses: ./.github/actions/integ-tests
-              with:
-                  testFile: ./.github/actions/integ-tests/tst/integ/preparePublish.test.js
+              env:
+                  TEST_FILE: ./.github/actions/integ-tests/tst/integ/preparePublish.test.js
 
     dry-run-release:
         name: Dry Run Release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@bpgeck/semantic-release-kaniko.svg)](https://www.npmjs.com/package/@bpgeck/semantic-release-kaniko)
 [![License](https://img.shields.io/npm/l/@bpgeck/semantic-release-kaniko.svg)](https://github.com/brendangeck/semantic-release-kaniko/blob/main/LICENSE)
+![CI](https://github.com/brendangeck/semantic-release-kaniko/actions/workflows/ci.yml/badge.svg)
 
 ## Overview
 
@@ -22,204 +23,57 @@ From the [Kaniko](https://github.com/GoogleContainerTools/kaniko/blob/main/READM
 -   **Cross-Platform Compatibility**: Works across different CI/CD platforms and environments that support Node.js and Kaniko.
 -   **Automated Publishing**: Pushes built images to your specified Docker registry as part of the release process, reducing manual steps.
 
-## Prerequisites
+## Quick Start
 
-This package must be run in an environment that has Kaniko already installed. We provide a container image with all the necessary dependencies pre-installed, which we strongly recommend using. You can pull the container image with the following command:
-
-```bash
-docker pull ghcr.io/brendangeck/semantic-release-kaniko:latest
-```
-
-## Installation
-
-To install, use the following command:
+Installation is done with the `npm install` command:
 
 ```bash
 npm install --save-dev @bpgeck/semantic-release-kaniko
 ```
 
-## Usage
-
-Add `@bpgeck/semantic-release-kaniko` to your semantic-release configuration. Here are examples of different `.releaserc` file formats:
-
-### YAML Example
-
-```yaml
-branches:
-    - main
-plugins:
-    - '@semantic-release/commit-analyzer'
-    - '@semantic-release/git'
-    - - '@bpgeck/semantic-release-kaniko'
-      - registry: 'registry.example.com'
-        image: 'my-project/my-image'
-        tags:
-            - '${version}'
-            - 'latest'
-        username: ${DOCKER_USERNAME}
-        password: ${DOCKER_PASSWORD}
-        insecure: false
-```
-
-### JSON Example
+Add the plugin to your [semantic-release](https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file) `.releaserc` file:
 
 ```json
 {
     "branches": ["main"],
     "plugins": [
         "@semantic-release/commit-analyzer",
-        "@semantic-release/git",
         [
             "@bpgeck/semantic-release-kaniko",
             {
-                "registry": "registry.example.com",
-                "image": "my-project/my-image",
-                "tags": ["${version}", "latest"],
-                "username": "${DOCKER_USERNAME}",
-                "password": "${DOCKER_PASSWORD}",
-                "insecure": false
+                "destination": [
+                    "registry.example.com/my-project/my-image:${version}",
+                    "registry.example.com/my-project/my-image:latest"
+                ]
             }
         ]
     ]
 }
 ```
 
-### JavaScript Example
+This package must be run in an environment that has Kaniko already installed. We provide a image with all the necessary dependencies pre-installed, which we strongly recommend using. Pull the container image:
 
-```javascript
-module.exports = {
-    branches: ['main'],
-    plugins: [
-        '@semantic-release/commit-analyzer',
-        '@semantic-release/git',
-        [
-            '@bpgeck/semantic-release-kaniko',
-            {
-                registry: 'registry.example.com',
-                image: 'my-project/my-image',
-                tags: ['${version}', 'latest'],
-                username: process.env.DOCKER_USERNAME,
-                password: process.env.DOCKER_PASSWORD,
-                insecure: false,
-            },
-        ],
-    ],
-};
+```bash
+docker pull ghcr.io/brendangeck/semantic-release-kaniko:latest
 ```
 
-## Example Workflows
+Run your semantic-release command in the container:
 
-Below are examples of how to use this package in popular CI environments.
-
-### GitHub Actions
-
-```yaml
-name: Release
-
-on:
-    push:
-        branches:
-            - main
-
-jobs:
-    release:
-        runs-on: ubuntu-latest
-        container:
-            image: ghcr.io/brendangeck/semantic-release-kaniko:latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v3
-
-            - name: Set up Node.js
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '20.x'
-
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Release
-              run: npx semantic-release
-              env:
-                  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-                  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+```
+docker run --rm \
+    -v $(pwd):/workspace \
+    -name semantic-release-kaniko-test \
+    ghcr.io/brendangeck/semantic-release-kaniko:latest \
+    npx semantic-release
 ```
 
-### GitLab CI
+## Advanced Usage
 
-```yaml
-stages:
-    - release
-
-release:
-    stage: release
-    image: ghcr.io/brendangeck/semantic-release-kaniko:latest
-    script:
-        - npm ci
-        - npx semantic-release
-    only:
-        - main
-    variables:
-        DOCKER_USERNAME: $DOCKER_USERNAME
-        DOCKER_PASSWORD: $DOCKER_PASSWORD
-```
-
-### CircleCI
-
-```yaml
-version: 2.1
-
-executors:
-    kaniko:
-        docker:
-            - image: ghcr.io/brendangeck/semantic-release-kaniko:latest
-
-jobs:
-    release:
-        executor: kaniko
-        steps:
-            - checkout
-            - run:
-                  name: Install dependencies
-                  command: npm ci
-            - run:
-                  name: Run semantic-release
-                  command: npx semantic-release
-                  environment:
-                      DOCKER_USERNAME: $DOCKER_USERNAME
-                      DOCKER_PASSWORD: $DOCKER_PASSWORD
-
-workflows:
-    version: 2
-    release:
-        jobs:
-            - release:
-                  filters:
-                      branches:
-                          only: main
-```
-
-## Configuration
-
-| .releaserc | env var         | Description                                                                                                                          |
-| ---------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| registry   | REGISTRY        | The Docker registry to push images to.                                                                                               |
-| image      | IMAGE           | The Docker image name.                                                                                                               |
-| tags       | TAGS            | An array of tags to apply to the Docker image. For env var, a comma-separated list of tags to apply to the image.                    |
-| dockerfile | DOCKERFILE      | (Optional) The path to the Dockerfile to be built into a Docker image. Defaults to 'Dockerfile'                                      |
-| username   | DOCKER_USERNAME | (Optional) The username for Docker registry authentication.                                                                          |
-| password   | DOCKER_PASSWORD | (Optional) The password for Docker registry authentication.                                                                          |
-| insecure   | INSECURE        | (Optional) Set to `true` to skip Docker registry TLS verification. This should be used only for testing or development environments. |
-| target     | TARGET          | (Optional) The target build stage to build in a multi-stage Dockerfile.                                                              |
-| cache      | CACHE           | (Optional) Set to `true` to enable caching in Kaniko.                                                                                |
-| cacheTTL   | CACHE_TTL       | (Optional) TTL for cached layers. Cache must be set to `true`. Defaults to '24h' if cache is enabled.                                |
-| kanikoDir  | KANIKO_DIR      | (Optional) Specify the directory where Kaniko will store its intermediate files, such as the image layers, during the build process  |
-
-.releaserc configuration takes precedence over environment variables if both are provided.
+For more advanced usage and detailed configuration options, including setting custom Dockerfile paths, custom registry configurations, as well as guidance on multiple CI environments and documentation for all supported flags, please refer to the [Usage Guide](docs/usage.md) or the [Configuration Guide](docs/configuration.md).
 
 ## Contributing
 
-We welcome contributions to semantic-release-kaniko!
+We welcome contributions to semantic-release-kaniko! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get involved.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For more advanced usage and detailed configuration options, including setting cu
 
 ## Contributing
 
-We welcome contributions to semantic-release-kaniko! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to get involved.
+We welcome contributions to semantic-release-kaniko! Simply raise and Issue or a PR and we can review it ASAP.
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,21 @@
 version: '3.8'
 
 services:
-    test-runner:
+    test-suite-verify-conditions:
         build: .
         volumes:
             - .:/usr/src/app
         working_dir: /usr/src/app
-        command: npx mocha 'tst/integ/**/*.test.js'
+        command: npx mocha 'tst/integ/verifyConditions.test.js'
+        depends_on:
+            - mock-registry
+
+    test-suite-prepare-publish:
+        build: .
+        volumes:
+            - .:/usr/src/app
+        working_dir: /usr/src/app
+        command: npx mocha 'tst/integ/preparePublish.test.js'
         depends_on:
             - mock-registry
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ This flag allows you to pass in build arguments as key-value pairs. Use an array
 **Environment variable:**
 
 ```shell
-BUILD_ARG='[{"name":"MY_VAR","value":"value with spaces"},{"name":"MY_VAR_2","value":"ValueWithNoSpaces"}]'
+KANIKO_BUILD_ARG='[{"name":"MY_VAR","value":"value with spaces"},{"name":"MY_VAR_2","value":"ValueWithNoSpaces"}]'
 ```
 
 Note that passing values that contain spaces is not natively supported - you need to ensure that the IFS is set to null before your executor command. You can set this by setting the `IFS` env var like so: `IFS=''`
@@ -54,7 +54,7 @@ This flag enables the use of cache when building the image.
 **Environment variable:**
 
 ```shell
-CACHE=true
+KANIKO_CACHE=true
 ```
 
 ### cacheCopyLayers
@@ -77,7 +77,7 @@ This flag enables caching of copy layers.
 **Environment variable:**
 
 ```shell
-CACHE_COPY_LAYERS=true
+KANIKO_CACHE_COPY_LAYERS=true
 ```
 
 ### cacheDir
@@ -100,7 +100,7 @@ This flag specifies a local directory to use as a cache.
 **Environment variable:**
 
 ```shell
-CACHE_DIR="/custom/cache/directory"
+KANIKO_CACHE_DIR="/custom/cache/directory"
 ```
 
 ### cacheRepo
@@ -123,7 +123,7 @@ This flag specifies a repository to use as a cache.
 **Environment variable:**
 
 ```shell
-CACHE_REPO="oci:/path/to/cache/repo"
+KANIKO_CACHE_REPO="oci:/path/to/cache/repo"
 ```
 
 ### cacheRunLayers
@@ -146,7 +146,7 @@ This flag enables caching of run layers.
 **Environment variable:**
 
 ```shell
-CACHE_RUN_LAYERS=true
+KANIKO_CACHE_RUN_LAYERS=true
 ```
 
 ### cacheTTL
@@ -169,7 +169,7 @@ This flag sets the cache timeout with a value and unit of duration.
 **Environment variable:**
 
 ```shell
-CACHE_TTL="24h"
+KANIKO_CACHE_TTL="24h"
 ```
 
 ### cleanup
@@ -192,7 +192,7 @@ This flag enables cleaning the filesystem at the end of the build.
 **Environment variable:**
 
 ```shell
-CLEANUP=true
+KANIKO_CLEANUP=true
 ```
 
 ### compressedCaching
@@ -215,7 +215,7 @@ This flag enables compression of cached layers.
 **Environment variable:**
 
 ```shell
-COMPRESSED_CACHING=true
+KANIKO_COMPRESSED_CACHING=true
 ```
 
 ### compression
@@ -238,7 +238,7 @@ This flag specifies the compression algorithm to use.
 **Environment variable:**
 
 ```shell
-COMPRESSION="zstd"
+KANIKO_COMPRESSION="zstd"
 ```
 
 ### compressionLevel
@@ -261,7 +261,7 @@ This flag sets the compression level.
 **Environment variable:**
 
 ```shell
-COMPRESSION_LEVEL=5
+KANIKO_COMPRESSION_LEVEL=5
 ```
 
 ### context
@@ -284,7 +284,7 @@ This flag specifies the path to the dockerfile build context.
 **Environment variable:**
 
 ```shell
-CONTEXT="/custom/build/context"
+KANIKO_CONTEXT="/custom/build/context"
 ```
 
 ### contextSubPath
@@ -307,7 +307,7 @@ This flag specifies a subpath within the given context.
 **Environment variable:**
 
 ```shell
-CONTEXT_SUB_PATH="subdir"
+KANIKO_CONTEXT_SUB_PATH="subdir"
 ```
 
 ### customPlatform
@@ -330,7 +330,7 @@ This flag specifies the build platform.
 **Environment variable:**
 
 ```shell
-CUSTOM_PLATFORM="linux/arm64"
+KANIKO_CUSTOM_PLATFORM="linux/arm64"
 ```
 
 ### destination
@@ -356,7 +356,7 @@ This flag specifies the registry the final image should be pushed to.
 **Environment variable:**
 
 ```shell
-DESTINATION='["registry.example.com/my-project/my-image:\${version}","registry.example.com/my-project/my-image:latest"]'
+KANIKO_DESTINATION='["registry.example.com/my-project/my-image:\${version}","registry.example.com/my-project/my-image:latest"]'
 ```
 
 ### digestFile
@@ -379,7 +379,7 @@ This flag specifies a file to save the digest of the built image to.
 **Environment variable:**
 
 ```shell
-DIGEST_FILE="/path/to/digest/file"
+KANIKO_DIGEST_FILE="/path/to/digest/file"
 ```
 
 ### dockerfile
@@ -402,7 +402,7 @@ This flag specifies the path to the dockerfile to be built.
 **Environment variable:**
 
 ```shell
-DOCKERFILE="custom.Dockerfile"
+KANIKO_DOCKERFILE="custom.Dockerfile"
 ```
 
 ### force
@@ -425,7 +425,7 @@ This flag forces building outside of a container.
 **Environment variable:**
 
 ```shell
-FORCE=true
+KANIKO_FORCE=true
 ```
 
 ### registryClientCert
@@ -457,7 +457,7 @@ This flag specifies client certificates for mutual TLS communication with regist
 **Environment variable:**
 
 ```shell
-REGISTRY_CLIENT_CERT='{"my.first.registry.url":{"cert":"/path/to/first/client/cert","key":"/path/to/first/client/key"},"my.second.registry.url":{"cert":"/path/to/second/client/cert","key":"/path/to/second/client/key"}}'
+KANIKO_REGISTRY_CLIENT_CERT='{"my.first.registry.url":{"cert":"/path/to/first/client/cert","key":"/path/to/first/client/key"},"my.second.registry.url":{"cert":"/path/to/second/client/cert","key":"/path/to/second/client/key"}}'
 ```
 
 Below is how you can add the `--registry-map` flag to your configuration file documentation, including both the `.releaserc` configuration and environment variable representation:
@@ -529,7 +529,7 @@ This flag forces the addition of metadata layers to the build image.
 **Environment variable:**
 
 ```shell
-FORCE_BUILD_METADATA=true
+KANIKO_FORCE_BUILD_METADATA=true
 ```
 
 ### git
@@ -556,7 +556,7 @@ This flag specifies git options for cloning when the build context is a git repo
 **Environment variable:**
 
 ```shell
-GIT='{"branch":"main","singleBranch":true,"recurseSubmodules":true}'
+KANIKO_GIT='{"branch":"main","singleBranch":true,"recurseSubmodules":true}'
 ```
 
 ### ignorePath
@@ -579,7 +579,7 @@ This flag specifies paths to ignore when taking a snapshot. Use an array for mul
 **Environment variable:**
 
 ```shell
-IGNORE_PATH='["/path/to/ignore1","/path/to/ignore2"]'
+KANIKO_IGNORE_PATH='["/path/to/ignore1","/path/to/ignore2"]'
 ```
 
 ### ignoreVarRun
@@ -602,7 +602,7 @@ This flag controls whether to ignore the `/var/run` directory when taking an ima
 **Environment variable:**
 
 ```shell
-IGNORE_VAR_RUN=false
+KANIKO_IGNORE_VAR_RUN=false
 ```
 
 ### imageDownloadRetry
@@ -625,7 +625,7 @@ This flag specifies the number of retries for downloading a remote image.
 **Environment variable:**
 
 ```shell
-IMAGE_DOWNLOAD_RETRY=3
+KANIKO_IMAGE_DOWNLOAD_RETRY=3
 ```
 
 ### imageFsExtractRetry
@@ -648,7 +648,7 @@ This flag sets the number of retries for extracting the image filesystem.
 **Environment variable:**
 
 ```shell
-IMAGE_FS_EXTRACT_RETRY=3
+KANIKO_IMAGE_FS_EXTRACT_RETRY=3
 ```
 
 ### imageNameTagWithDigestFile
@@ -671,7 +671,7 @@ This flag specifies a file to save the image name with tag and digest informatio
 **Environment variable:**
 
 ```shell
-IMAGE_NAME_TAG_WITH_DIGEST_FILE="/path/to/image/info/file"
+KANIKO_IMAGE_NAME_TAG_WITH_DIGEST_FILE="/path/to/image/info/file"
 ```
 
 ### imageNameWithDigestFile
@@ -694,7 +694,7 @@ This flag specifies a file to save the image name with digest information.
 **Environment variable:**
 
 ```shell
-IMAGE_NAME_WITH_DIGEST_FILE="/path/to/image/digest/file"
+KANIKO_IMAGE_NAME_WITH_DIGEST_FILE="/path/to/image/digest/file"
 ```
 
 ### insecure
@@ -717,7 +717,7 @@ This flag enables pushing to an insecure registry using plain HTTP.
 **Environment variable:**
 
 ```shell
-INSECURE=true
+KANIKO_INSECURE=true
 ```
 
 ### insecurePull
@@ -740,7 +740,7 @@ This flag allows pulling from an insecure registry using plain HTTP.
 **Environment variable:**
 
 ```shell
-INSECURE_PULL=true
+KANIKO_INSECURE_PULL=true
 ```
 
 ### insecureRegistry
@@ -763,7 +763,7 @@ This flag specifies a list of insecure registries using plain HTTP for both push
 **Environment variable:**
 
 ```shell
-INSECURE_REGISTRY='["registry1.example.com","registry2.example.com"]'
+KANIKO_INSECURE_REGISTRY='["registry1.example.com","registry2.example.com"]'
 ```
 
 ### kanikoDir
@@ -786,8 +786,10 @@ This flag specifies the path to the Kaniko directory. This setting overrides the
 **Environment variable:**
 
 ```shell
-KANIKO_DIR="/custom/kaniko/dir"
+KANIKO_KANIKO_DIR="/custom/kaniko/dir"
 ```
+
+Notice how we have `KANIKO` twice here. The first prefix is how we namespace env vars the plugin uses. The second prefix is for the kaniko variable name itself (which is `--kaniko-dir`).
 
 ### label
 
@@ -812,7 +814,7 @@ This flag sets metadata labels for an image. Use an array of objects for multipl
 **Environment variable:**
 
 ```shell
-LABEL='[{"name":"maintainer","value":"John Doe"},{"name":"version","value":"1.0.0"}]'
+KANIKO_LABEL='[{"name":"maintainer","value":"John Doe"},{"name":"version","value":"1.0.0"}]'
 ```
 
 ### logFormat
@@ -835,7 +837,7 @@ This flag specifies the format of the logs. Options are `"text"`, `"color"`, or 
 **Environment variable:**
 
 ```shell
-LOG_FORMAT="json"
+KANIKO_LOG_FORMAT="json"
 ```
 
 ### logTimestamp
@@ -858,7 +860,7 @@ This flag enables timestamps in the log output.
 **Environment variable:**
 
 ```shell
-LOG_TIMESTAMP=true
+KANIKO_LOG_TIMESTAMP=true
 ```
 
 ### noPush
@@ -881,7 +883,7 @@ This flag disables pushing the built image to the registry.
 **Environment variable:**
 
 ```shell
-NO_PUSH=true
+KANIKO_NO_PUSH=true
 ```
 
 ### noPushCache
@@ -904,7 +906,7 @@ This flag disables pushing cache layers to the registry.
 **Environment variable:**
 
 ```shell
-NO_PUSH_CACHE=true
+KANIKO_NO_PUSH_CACHE=true
 ```
 
 ### ociLayoutPath
@@ -927,7 +929,7 @@ This flag specifies the path to save the OCI image layout.
 **Environment variable:**
 
 ```shell
-OCI_LAYOUT_PATH="/path/to/oci/layout"
+KANIKO_OCI_LAYOUT_PATH="/path/to/oci/layout"
 ```
 
 ### pushIgnoreImmutableTagErrors
@@ -950,7 +952,7 @@ This flag, when set to `true`, ignores tag immutability errors during push opera
 **Environment variable:**
 
 ```shell
-PUSH_IGNORE_IMMUTABLE_TAG_ERRORS=true
+KANIKO_PUSH_IGNORE_IMMUTABLE_TAG_ERRORS=true
 ```
 
 ### pushRetry
@@ -973,7 +975,7 @@ This flag specifies the number of retries for the push operation.
 **Environment variable:**
 
 ```shell
-PUSH_RETRY=3
+KANIKO_PUSH_RETRY=3
 ```
 
 ### registryCertificate
@@ -998,7 +1000,7 @@ This flag specifies the certificate for TLS communication with a given registry.
 **Environment variable:**
 
 ```shell
-REGISTRY_CERTIFICATE='{"my.registry.url":"/path/to/the/server/certificate"}'
+KANIKO_REGISTRY_CERTIFICATE='{"my.registry.url":"/path/to/the/server/certificate"}'
 ```
 
 ### registryMirror
@@ -1021,7 +1023,7 @@ This flag specifies a list of registry mirrors for pull-through caching instead 
 **Environment variable:**
 
 ```shell
-REGISTRY_MIRROR='["mirror1.example.com","mirror2.example.com"]'
+KANIKO_REGISTRY_MIRROR='["mirror1.example.com","mirror2.example.com"]'
 ```
 
 ### reproducible
@@ -1046,7 +1048,7 @@ This flag strips timestamps out of the image to make it reproducible.
 **Environment variable:**
 
 ```shell
-REPRODUCIBLE=true
+KANIKO_REPRODUCIBLE=true
 ```
 
 ### singleSnapshot
@@ -1069,7 +1071,7 @@ This flag takes a single snapshot at the end of the build process.
 **Environment variable:**
 
 ```shell
-SINGLE_SNAPSHOT=true
+KANIKO_SINGLE_SNAPSHOT=true
 ```
 
 ### skipDefaultRegistryFallback
@@ -1092,7 +1094,7 @@ This flag prevents fallback to the default registry if an image is not found on 
 **Environment variable:**
 
 ```shell
-SKIP_DEFAULT_REGISTRY_FALLBACK=true
+KANIKO_SKIP_DEFAULT_REGISTRY_FALLBACK=true
 ```
 
 ### skipPushPermissionCheck
@@ -1115,7 +1117,7 @@ This flag skips checking push permissions.
 **Environment variable:**
 
 ```shell
-SKIP_PUSH_PERMISSION_CHECK=true
+KANIKO_SKIP_PUSH_PERMISSION_CHECK=true
 ```
 
 ### skipTlsVerify
@@ -1138,7 +1140,7 @@ This flag enables pushing to an insecure registry without TLS verification.
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY=true
+KANIKO_SKIP_TLS_VERIFY=true
 ```
 
 ### skipTlsVerifyPull
@@ -1161,7 +1163,7 @@ This flag enables pulling from an insecure registry without TLS verification.
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY_PULL=true
+KANIKO_SKIP_TLS_VERIFY_PULL=true
 ```
 
 ### skipTlsVerifyRegistry
@@ -1184,7 +1186,7 @@ This flag specifies registries to ignore TLS verification for push and pull oper
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY_REGISTRY='["registry1.example.com","registry2.example.com"]'
+KANIKO_SKIP_TLS_VERIFY_REGISTRY='["registry1.example.com","registry2.example.com"]'
 ```
 
 ### skipUnusedStages
@@ -1207,7 +1209,7 @@ This flag builds only the used stages, ignoring unnecessary ones.
 **Environment variable:**
 
 ```shell
-SKIP_UNUSED_STAGES=true
+KANIKO_SKIP_UNUSED_STAGES=true
 ```
 
 ### snapshotMode
@@ -1230,7 +1232,7 @@ This flag changes the file attributes inspected during snapshotting.
 **Environment variable:**
 
 ```shell
-SNAPSHOT_MODE="time"
+KANIKO_SNAPSHOT_MODE="time"
 ```
 
 ### tarPath
@@ -1253,7 +1255,7 @@ This flag specifies the path to save the image as a tarball instead of pushing i
 **Environment variable:**
 
 ```shell
-TAR_PATH="/path/to/save/image.tar"
+KANIKO_TAR_PATH="/path/to/save/image.tar"
 ```
 
 ### target
@@ -1276,7 +1278,7 @@ This flag sets the target build stage.
 **Environment variable:**
 
 ```shell
-TARGET="production"
+KANIKO_TARGET="production"
 ```
 
 ### useNewRun
@@ -1299,7 +1301,7 @@ This flag enables the use of an experimental run implementation for detecting ch
 **Environment variable:**
 
 ```shell
-USE_NEW_RUN=true
+KANIKO_USE_NEW_RUN=true
 ```
 
 ### verbosity
@@ -1322,5 +1324,5 @@ This flag sets the log level for output. Options include `"trace"`, `"debug"`, `
 **Environment variable:**
 
 ```shell
-VERBOSITY="debug"
+KANIKO_VERBOSITY="debug"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,6 +32,8 @@ This flag allows you to pass in build arguments as key-value pairs. Use an array
 BUILD_ARG='[{"name":"MY_VAR","value":"value with spaces"},{"name":"MY_VAR_2","value":"ValueWithNoSpaces"}]'
 ```
 
+Note that passing values that contain spaces is not natively supported - you need to ensure that the IFS is set to null before your executor command. You can set this by setting the `IFS` env var like so: `IFS=''`
+
 ### cache
 
 This flag enables the use of cache when building the image.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,11 +2,13 @@
 
 ## Supported Kaniko Flags
 
-This section lists the flags supported by the `@bpgeck/semantic-release-kaniko` plugin. All are directly from [Kaniko](https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#additional-flags)
+This section lists the flags supported by the `@bpgeck/semantic-release-kaniko` plugin. All are directly from [Kaniko](https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#additional-flags).
+
+We allow using either `.releaserc` or environment variables to configure the plugin. If both are set, the configuration in `.releaserc` is preferred. Environment variables should be represented as JSON if they contain anything more than a single key-value pair.
 
 ### buildArg
 
-This flag allows you to pass in ARG values at build time. Use an array for multiple values.
+This flag allows you to pass in build arguments as key-value pairs. Use an array of objects for multiple values.
 
 **.releaserc:**
 
@@ -15,7 +17,10 @@ This flag allows you to pass in ARG values at build time. Use an array for multi
     "plugins": [
         "@bpgeck/semantic-release-kaniko",
         {
-            "buildArg": ["MY_VAR='value with spaces'", "MY_VAR_2=ValueWithNoSpaces"]
+            "buildArg": [
+                {"name": "MY_VAR", "value": "value with spaces"},
+                {"name": "MY_VAR_2", "value": "ValueWithNoSpaces"}
+            ]
         }
     ]
 }
@@ -24,7 +29,7 @@ This flag allows you to pass in ARG values at build time. Use an array for multi
 **Environment variable:**
 
 ```shell
-BUILD_ARG="MY_VAR='value with spaces',MY_VAR_2=ValueWithNoSpaces"
+BUILD_ARG='[{"name":"MY_VAR","value":"value with spaces"},{"name":"MY_VAR_2","value":"ValueWithNoSpaces"}]'
 ```
 
 ### cache
@@ -47,7 +52,7 @@ This flag enables the use of cache when building the image.
 **Environment variable:**
 
 ```shell
-CACHE="true"
+CACHE=true
 ```
 
 ### cacheCopyLayers
@@ -70,12 +75,12 @@ This flag enables caching of copy layers.
 **Environment variable:**
 
 ```shell
-CACHE_COPY_LAYERS="true"
+CACHE_COPY_LAYERS=true
 ```
 
 ### cacheDir
 
-This flag specifies a local directory to use as a cache. The default value is "/cache".
+This flag specifies a local directory to use as a cache.
 
 **.releaserc:**
 
@@ -98,7 +103,7 @@ CACHE_DIR="/custom/cache/directory"
 
 ### cacheRepo
 
-This flag specifies a repository to use as a cache. If not provided, one will be inferred from the destination. When prefixed with 'oci:', the repository will be written in OCI image layout format at the path provided.
+This flag specifies a repository to use as a cache.
 
 **.releaserc:**
 
@@ -121,7 +126,7 @@ CACHE_REPO="oci:/path/to/cache/repo"
 
 ### cacheRunLayers
 
-This flag enables caching of run layers. It is set to true by default.
+This flag enables caching of run layers.
 
 **.releaserc:**
 
@@ -139,12 +144,12 @@ This flag enables caching of run layers. It is set to true by default.
 **Environment variable:**
 
 ```shell
-CACHE_RUN_LAYERS="true"
+CACHE_RUN_LAYERS=true
 ```
 
 ### cacheTTL
 
-This flag sets the cache timeout. It requires a value and unit of duration, for example, "6h". The default is two weeks (336h0m0s).
+This flag sets the cache timeout with a value and unit of duration.
 
 **.releaserc:**
 
@@ -185,12 +190,12 @@ This flag enables cleaning the filesystem at the end of the build.
 **Environment variable:**
 
 ```shell
-CLEANUP="true"
+CLEANUP=true
 ```
 
 ### compressedCaching
 
-This flag enables compression of cached layers. It decreases build time but increases memory usage. It is set to true by default.
+This flag enables compression of cached layers.
 
 **.releaserc:**
 
@@ -208,12 +213,12 @@ This flag enables compression of cached layers. It decreases build time but incr
 **Environment variable:**
 
 ```shell
-COMPRESSED_CACHING="true"
+COMPRESSED_CACHING=true
 ```
 
 ### compression
 
-This flag specifies the compression algorithm to use. Options are "gzip" or "zstd".
+This flag specifies the compression algorithm to use.
 
 **.releaserc:**
 
@@ -236,7 +241,7 @@ COMPRESSION="zstd"
 
 ### compressionLevel
 
-This flag sets the compression level. The default value is -1.
+This flag sets the compression level.
 
 **.releaserc:**
 
@@ -254,12 +259,12 @@ This flag sets the compression level. The default value is -1.
 **Environment variable:**
 
 ```shell
-COMPRESSION_LEVEL="5"
+COMPRESSION_LEVEL=5
 ```
 
 ### context
 
-This flag specifies the path to the dockerfile build context. The default value is "/workspace/".
+This flag specifies the path to the dockerfile build context.
 
 **.releaserc:**
 
@@ -282,7 +287,7 @@ CONTEXT="/custom/build/context"
 
 ### contextSubPath
 
-This flag specifies a sub path within the given context.
+This flag specifies a subpath within the given context.
 
 **.releaserc:**
 
@@ -305,7 +310,7 @@ CONTEXT_SUB_PATH="subdir"
 
 ### customPlatform
 
-This flag specifies the build platform if different from the current host.
+This flag specifies the build platform.
 
 **.releaserc:**
 
@@ -328,7 +333,7 @@ CUSTOM_PLATFORM="linux/arm64"
 
 ### destination
 
-This flag specifies the registry the final image should be pushed to. Use an array for multiple destinations.
+This flag specifies the registry the final image should be pushed to.
 
 **.releaserc:**
 
@@ -349,7 +354,7 @@ This flag specifies the registry the final image should be pushed to. Use an arr
 **Environment variable:**
 
 ```shell
-DESTINATION="registry.example.com/my-project/my-image:${version},registry.example.com/my-project/my-image:latest"
+DESTINATION='["registry.example.com/my-project/my-image:\${version}","registry.example.com/my-project/my-image:latest"]'
 ```
 
 ### digestFile
@@ -377,7 +382,7 @@ DIGEST_FILE="/path/to/digest/file"
 
 ### dockerfile
 
-This flag specifies the path to the dockerfile to be built. The default value is "Dockerfile".
+This flag specifies the path to the dockerfile to be built.
 
 **.releaserc:**
 
@@ -418,12 +423,93 @@ This flag forces building outside of a container.
 **Environment variable:**
 
 ```shell
-FORCE="true"
+FORCE=true
+```
+
+### registryClientCert
+
+This flag specifies client certificates for mutual TLS communication with registries.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryClientCert": {
+                "my.first.registry.url": {
+                    "cert": "/path/to/first/client/cert",
+                    "key": "/path/to/first/client/key"
+                },
+                "my.second.registry.url": {
+                    "cert": "/path/to/second/client/cert",
+                    "key": "/path/to/second/client/key"
+                }
+            }
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REGISTRY_CLIENT_CERT='{"my.first.registry.url":{"cert":"/path/to/first/client/cert","key":"/path/to/first/client/key"},"my.second.registry.url":{"cert":"/path/to/second/client/cert","key":"/path/to/second/client/key"}}'
+```
+
+Below is how you can add the `--registry-map` flag to your configuration file documentation, including both the `.releaserc` configuration and environment variable representation:
+
+---
+
+### registryMap
+
+This flag allows you to remap registry references. It is useful for scenarios like air-gapped environments, where you might want to redirect registry requests to local mirrors or specific internal registries. You can specify multiple remapped registries for a single original registry. Kaniko will try each remapped registry in order and fall back on the original registry if none of the mirrors are available.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryMap": [
+                {
+                    "original": "index.docker.io",
+                    "remapped": ["docker-io.mirrors.corp.net", "mirror.gcr.io"]
+                },
+                {
+                    "original": "gcr.io",
+                    "remapped": ["127.0.0.1"]
+                },
+                {
+                    "original": "quay.io",
+                    "remapped": ["192.168.0.1:5000"]
+                },
+                {
+                    "original": "docker.io",
+                    "remapped": ["harbor.private.io/theproject"]
+                }
+            ]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+KANIKO_REGISTRY_MAP='[
+    {"original":"index.docker.io","remapped":["docker-io.mirrors.corp.net","mirror.gcr.io"]},
+    {"original":"gcr.io","remapped":["127.0.0.1"]},
+    {"original":"quay.io","remapped":["192.168.0.1:5000"]},
+    {"original":"docker.io","remapped":["harbor.private.io/theproject"]}
+]'
 ```
 
 ### forceBuildMetadata
 
-This flag forces adding metadata layers to the build image.
+This flag forces the addition of metadata layers to the build image.
 
 **.releaserc:**
 
@@ -441,12 +527,12 @@ This flag forces adding metadata layers to the build image.
 **Environment variable:**
 
 ```shell
-FORCE_BUILD_METADATA="true"
+FORCE_BUILD_METADATA=true
 ```
 
 ### git
 
-This flag specifies git options for cloning if the build context is a git repository.
+This flag specifies git options for cloning when the build context is a git repository.
 
 **.releaserc:**
 
@@ -468,7 +554,7 @@ This flag specifies git options for cloning if the build context is a git reposi
 **Environment variable:**
 
 ```shell
-GIT="branch=main,single-branch=true,recurse-submodules=true"
+GIT='{"branch":"main","singleBranch":true,"recurseSubmodules":true}'
 ```
 
 ### ignorePath
@@ -491,12 +577,12 @@ This flag specifies paths to ignore when taking a snapshot. Use an array for mul
 **Environment variable:**
 
 ```shell
-IGNORE_PATH="/path/to/ignore1,/path/to/ignore2"
+IGNORE_PATH='["/path/to/ignore1","/path/to/ignore2"]'
 ```
 
 ### ignoreVarRun
 
-This flag ignores the /var/run directory when taking an image snapshot. Set it to false to preserve /var/run/ in the destination image. The default value is true.
+This flag controls whether to ignore the `/var/run` directory when taking an image snapshot.
 
 **.releaserc:**
 
@@ -514,14 +600,12 @@ This flag ignores the /var/run directory when taking an image snapshot. Set it t
 **Environment variable:**
 
 ```shell
-IGNORE_VAR_RUN="
-
-false"
+IGNORE_VAR_RUN=false
 ```
 
 ### imageDownloadRetry
 
-This flag specifies the number of retries for downloading the remote image.
+This flag specifies the number of retries for downloading a remote image.
 
 **.releaserc:**
 
@@ -539,12 +623,12 @@ This flag specifies the number of retries for downloading the remote image.
 **Environment variable:**
 
 ```shell
-IMAGE_DOWNLOAD_RETRY="3"
+IMAGE_DOWNLOAD_RETRY=3
 ```
 
 ### imageFsExtractRetry
 
-This flag specifies the number of retries for image filesystem extraction.
+This flag sets the number of retries for extracting the image filesystem.
 
 **.releaserc:**
 
@@ -562,12 +646,12 @@ This flag specifies the number of retries for image filesystem extraction.
 **Environment variable:**
 
 ```shell
-IMAGE_FS_EXTRACT_RETRY="3"
+IMAGE_FS_EXTRACT_RETRY=3
 ```
 
 ### imageNameTagWithDigestFile
 
-This flag specifies a file to save the image name with image tag and digest of the built image to.
+This flag specifies a file to save the image name with tag and digest information.
 
 **.releaserc:**
 
@@ -590,7 +674,7 @@ IMAGE_NAME_TAG_WITH_DIGEST_FILE="/path/to/image/info/file"
 
 ### imageNameWithDigestFile
 
-This flag specifies a file to save the image name with digest of the built image to.
+This flag specifies a file to save the image name with digest information.
 
 **.releaserc:**
 
@@ -631,12 +715,12 @@ This flag enables pushing to an insecure registry using plain HTTP.
 **Environment variable:**
 
 ```shell
-INSECURE="true"
+INSECURE=true
 ```
 
 ### insecurePull
 
-This flag enables pulling from an insecure registry using plain HTTP.
+This flag allows pulling from an insecure registry using plain HTTP.
 
 **.releaserc:**
 
@@ -654,12 +738,12 @@ This flag enables pulling from an insecure registry using plain HTTP.
 **Environment variable:**
 
 ```shell
-INSECURE_PULL="true"
+INSECURE_PULL=true
 ```
 
 ### insecureRegistry
 
-This flag specifies insecure registries using plain HTTP to push and pull. Use an array for multiple registries.
+This flag specifies a list of insecure registries using plain HTTP for both push and pull operations.
 
 **.releaserc:**
 
@@ -677,12 +761,12 @@ This flag specifies insecure registries using plain HTTP to push and pull. Use a
 **Environment variable:**
 
 ```shell
-INSECURE_REGISTRY="registry1.example.com,registry2.example.com"
+INSECURE_REGISTRY='["registry1.example.com","registry2.example.com"]'
 ```
 
 ### kanikoDir
 
-This flag specifies the path to the kaniko directory. It takes precedence over the KANIKO_DIR environment variable. The default value is "/kaniko".
+This flag specifies the path to the Kaniko directory. This setting overrides the `KANIKO_DIR` environment variable.
 
 **.releaserc:**
 
@@ -705,7 +789,7 @@ KANIKO_DIR="/custom/kaniko/dir"
 
 ### label
 
-This flag sets metadata for an image. Use an array for multiple labels.
+This flag sets metadata labels for an image. Use an array of objects for multiple labels.
 
 **.releaserc:**
 
@@ -714,7 +798,10 @@ This flag sets metadata for an image. Use an array for multiple labels.
     "plugins": [
         "@bpgeck/semantic-release-kaniko",
         {
-            "label": ["maintainer=John Doe", "version=1.0.0"]
+            "label": [
+                {"name": "maintainer", "value": "John Doe"},
+                {"name": "version", "value": "1.0.0"}
+            ]
         }
     ]
 }
@@ -723,12 +810,12 @@ This flag sets metadata for an image. Use an array for multiple labels.
 **Environment variable:**
 
 ```shell
-LABEL="maintainer=John Doe,version=1.0.0"
+LABEL='[{"name":"maintainer","value":"John Doe"},{"name":"version","value":"1.0.0"}]'
 ```
 
 ### logFormat
 
-This flag specifies the log format. Options are "text", "color", or "json". The default value is "color".
+This flag specifies the format of the logs. Options are `"text"`, `"color"`, or `"json"`.
 
 **.releaserc:**
 
@@ -751,7 +838,7 @@ LOG_FORMAT="json"
 
 ### logTimestamp
 
-This flag enables timestamp in log output.
+This flag enables timestamps in the log output.
 
 **.releaserc:**
 
@@ -769,12 +856,12 @@ This flag enables timestamp in log output.
 **Environment variable:**
 
 ```shell
-LOG_TIMESTAMP="true"
+LOG_TIMESTAMP=true
 ```
 
 ### noPush
 
-This flag disables pushing the image to the registry.
+This flag disables pushing the built image to the registry.
 
 **.releaserc:**
 
@@ -792,12 +879,12 @@ This flag disables pushing the image to the registry.
 **Environment variable:**
 
 ```shell
-NO_PUSH="true"
+NO_PUSH=true
 ```
 
 ### noPushCache
 
-This flag disables pushing the cache layers to the registry.
+This flag disables pushing cache layers to the registry.
 
 **.releaserc:**
 
@@ -815,12 +902,12 @@ This flag disables pushing the cache layers to the registry.
 **Environment variable:**
 
 ```shell
-NO_PUSH_CACHE="true"
+NO_PUSH_CACHE=true
 ```
 
 ### ociLayoutPath
 
-This flag specifies the path to save the OCI image layout of the built image.
+This flag specifies the path to save the OCI image layout.
 
 **.releaserc:**
 
@@ -843,7 +930,7 @@ OCI_LAYOUT_PATH="/path/to/oci/layout"
 
 ### pushIgnoreImmutableTagErrors
 
-This flag, when set to true, ignores known tag immutability errors and finishes the push operation with success.
+This flag, when set to `true`, ignores tag immutability errors during push operations.
 
 **.releaserc:**
 
@@ -861,7 +948,7 @@ This flag, when set to true, ignores known tag immutability errors and finishes 
 **Environment variable:**
 
 ```shell
-PUSH_IGNORE_IMMUTABLE_TAG_ERRORS="true"
+PUSH_IGNORE_IMMUTABLE_TAG_ERRORS=true
 ```
 
 ### pushRetry
@@ -884,12 +971,12 @@ This flag specifies the number of retries for the push operation.
 **Environment variable:**
 
 ```shell
-PUSH_RETRY="3"
+PUSH_RETRY=3
 ```
 
 ### registryCertificate
 
-This flag specifies the certificate to use for TLS communication with the given registry. Expected format is 'my.registry.url=/path/to/the/server/certificate'.
+This flag specifies the certificate for TLS communication with a given registry.
 
 **.releaserc:**
 
@@ -909,63 +996,12 @@ This flag specifies the certificate to use for TLS communication with the given 
 **Environment variable:**
 
 ```shell
-REGISTRY_CERTIFICATE="my.registry.url=/path/to/the/server/certificate"
-```
-
-### registryClientCert
-
-This flag specifies the client certificate to use for mutual TLS (mTLS) communication with the given registry. Expected format is 'my.registry.url=/path/to/client/cert,/path/to/client/key'.
-
-**.releaserc:**
-
-```json
-{
-    "plugins": [
-        "@bpgeck/semantic-release-kaniko",
-        {
-            "registryClientCert": {
-                "my.registry.url": "/path/to/client/cert,/path/to/client/key"
-            }
-        }
-    ]
-}
-```
-
-**Environment variable:**
-
-```shell
-REGISTRY_CLIENT_CERT="my.registry.url=/path/to/client/cert,/path/to/client/key"
-```
-
-### registryMap
-
-This flag specifies a registry map of mirror to use as pull-through cache instead. Expected format is 'original.registry=new.registry;other-original.registry=other-remap.registry'.
-
-**.releaserc:**
-
-```json
-{
-    "plugins": [
-        "@bpgeck/semantic-release-kaniko",
-        {
-            "registryMap": {
-                "original.registry": "new.registry",
-                "other-original.registry": "other-remap.registry"
-            }
-        }
-    ]
-}
-```
-
-**Environment variable:**
-
-```shell
-REGISTRY_MAP="original.registry=new.registry;other-original.registry=other-remap.registry"
+REGISTRY_CERTIFICATE='{"my.registry.url":"/path/to/the/server/certificate"}'
 ```
 
 ### registryMirror
 
-This flag specifies a registry mirror to use as pull-through cache instead of docker.io. Use an array for multiple mirrors.
+This flag specifies a list of registry mirrors for pull-through caching instead of using docker.io directly.
 
 **.releaserc:**
 
@@ -983,7 +1019,7 @@ This flag specifies a registry mirror to use as pull-through cache instead of do
 **Environment variable:**
 
 ```shell
-REGISTRY_MIRROR="mirror1.example.com,mirror2.example.com"
+REGISTRY_MIRROR='["mirror1.example.com","mirror2.example.com"]'
 ```
 
 ### reproducible
@@ -993,6 +1029,8 @@ This flag strips timestamps out of the image to make it reproducible.
 **.releaserc:**
 
 ```json
+
+
 {
     "plugins": [
         "@bpgeck/semantic-release-kaniko",
@@ -1006,16 +1044,14 @@ This flag strips timestamps out of the image to make it reproducible.
 **Environment variable:**
 
 ```shell
-REPRODUCIBLE="true"
+REPRODUCIBLE=true
 ```
 
 ### singleSnapshot
 
-This flag takes a single snapshot at the end of the build.
+This flag takes a single snapshot at the end of the build process.
 
-\*\*
-
-.releaserc:\*\*
+**.releaserc:**
 
 ```json
 {
@@ -1031,12 +1067,12 @@ This flag takes a single snapshot at the end of the build.
 **Environment variable:**
 
 ```shell
-SINGLE_SNAPSHOT="true"
+SINGLE_SNAPSHOT=true
 ```
 
 ### skipDefaultRegistryFallback
 
-This flag, when set, prevents fallback to the default registry if an image is not found on any mirrors (defined with registry-mirror). If registry-mirror is not defined, this flag is ignored.
+This flag prevents fallback to the default registry if an image is not found on defined mirrors.
 
 **.releaserc:**
 
@@ -1054,12 +1090,12 @@ This flag, when set, prevents fallback to the default registry if an image is no
 **Environment variable:**
 
 ```shell
-SKIP_DEFAULT_REGISTRY_FALLBACK="true"
+SKIP_DEFAULT_REGISTRY_FALLBACK=true
 ```
 
 ### skipPushPermissionCheck
 
-This flag skips the check of the push permission.
+This flag skips checking push permissions.
 
 **.releaserc:**
 
@@ -1077,12 +1113,12 @@ This flag skips the check of the push permission.
 **Environment variable:**
 
 ```shell
-SKIP_PUSH_PERMISSION_CHECK="true"
+SKIP_PUSH_PERMISSION_CHECK=true
 ```
 
 ### skipTlsVerify
 
-This flag enables pushing to an insecure registry ignoring TLS verify.
+This flag enables pushing to an insecure registry without TLS verification.
 
 **.releaserc:**
 
@@ -1100,12 +1136,12 @@ This flag enables pushing to an insecure registry ignoring TLS verify.
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY="true"
+SKIP_TLS_VERIFY=true
 ```
 
 ### skipTlsVerifyPull
 
-This flag enables pulling from an insecure registry ignoring TLS verify.
+This flag enables pulling from an insecure registry without TLS verification.
 
 **.releaserc:**
 
@@ -1123,12 +1159,12 @@ This flag enables pulling from an insecure registry ignoring TLS verify.
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY_PULL="true"
+SKIP_TLS_VERIFY_PULL=true
 ```
 
 ### skipTlsVerifyRegistry
 
-This flag specifies insecure registries ignoring TLS verify to push and pull. Use an array for multiple registries.
+This flag specifies registries to ignore TLS verification for push and pull operations.
 
 **.releaserc:**
 
@@ -1146,12 +1182,12 @@ This flag specifies insecure registries ignoring TLS verify to push and pull. Us
 **Environment variable:**
 
 ```shell
-SKIP_TLS_VERIFY_REGISTRY="registry1.example.com,registry2.example.com"
+SKIP_TLS_VERIFY_REGISTRY='["registry1.example.com","registry2.example.com"]'
 ```
 
 ### skipUnusedStages
 
-This flag, when set to true, builds only used stages. Otherwise, it builds all stages by default, even the unnecessary ones until it reaches the target stage / end of Dockerfile.
+This flag builds only the used stages, ignoring unnecessary ones.
 
 **.releaserc:**
 
@@ -1169,12 +1205,12 @@ This flag, when set to true, builds only used stages. Otherwise, it builds all s
 **Environment variable:**
 
 ```shell
-SKIP_UNUSED_STAGES="true"
+SKIP_UNUSED_STAGES=true
 ```
 
 ### snapshotMode
 
-This flag changes the file attributes inspected during snapshotting. The default value is "full".
+This flag changes the file attributes inspected during snapshotting.
 
 **.releaserc:**
 
@@ -1197,7 +1233,7 @@ SNAPSHOT_MODE="time"
 
 ### tarPath
 
-This flag specifies the path to save the image as a tarball instead of pushing.
+This flag specifies the path to save the image as a tarball instead of pushing it.
 
 **.releaserc:**
 
@@ -1220,7 +1256,7 @@ TAR_PATH="/path/to/save/image.tar"
 
 ### target
 
-This flag sets the target build stage to build.
+This flag sets the target build stage.
 
 **.releaserc:**
 
@@ -1243,7 +1279,7 @@ TARGET="production"
 
 ### useNewRun
 
-This flag enables the use of the experimental run implementation for detecting changes without requiring file system snapshots.
+This flag enables the use of an experimental run implementation for detecting changes.
 
 **.releaserc:**
 
@@ -1261,12 +1297,12 @@ This flag enables the use of the experimental run implementation for detecting c
 **Environment variable:**
 
 ```shell
-USE_NEW_RUN="true"
+USE_NEW_RUN=true
 ```
 
 ### verbosity
 
-This flag sets the log level. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic". The default value is "info".
+This flag sets the log level for output. Options include `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"fatal"`, `"panic"`.
 
 **.releaserc:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,1288 @@
+# Configuration
+
+## Supported Kaniko Flags
+
+This section lists the flags supported by the `@bpgeck/semantic-release-kaniko` plugin. All are directly from [Kaniko](https://github.com/GoogleContainerTools/kaniko?tab=readme-ov-file#additional-flags)
+
+### buildArg
+
+This flag allows you to pass in ARG values at build time. Use an array for multiple values.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "buildArg": ["MY_VAR='value with spaces'", "MY_VAR_2=ValueWithNoSpaces"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+BUILD_ARG="MY_VAR='value with spaces',MY_VAR_2=ValueWithNoSpaces"
+```
+
+### cache
+
+This flag enables the use of cache when building the image.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cache": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE="true"
+```
+
+### cacheCopyLayers
+
+This flag enables caching of copy layers.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cacheCopyLayers": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE_COPY_LAYERS="true"
+```
+
+### cacheDir
+
+This flag specifies a local directory to use as a cache. The default value is "/cache".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cacheDir": "/custom/cache/directory"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE_DIR="/custom/cache/directory"
+```
+
+### cacheRepo
+
+This flag specifies a repository to use as a cache. If not provided, one will be inferred from the destination. When prefixed with 'oci:', the repository will be written in OCI image layout format at the path provided.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cacheRepo": "oci:/path/to/cache/repo"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE_REPO="oci:/path/to/cache/repo"
+```
+
+### cacheRunLayers
+
+This flag enables caching of run layers. It is set to true by default.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cacheRunLayers": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE_RUN_LAYERS="true"
+```
+
+### cacheTTL
+
+This flag sets the cache timeout. It requires a value and unit of duration, for example, "6h". The default is two weeks (336h0m0s).
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cacheTTL": "24h"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CACHE_TTL="24h"
+```
+
+### cleanup
+
+This flag enables cleaning the filesystem at the end of the build.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "cleanup": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CLEANUP="true"
+```
+
+### compressedCaching
+
+This flag enables compression of cached layers. It decreases build time but increases memory usage. It is set to true by default.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "compressedCaching": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+COMPRESSED_CACHING="true"
+```
+
+### compression
+
+This flag specifies the compression algorithm to use. Options are "gzip" or "zstd".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "compression": "zstd"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+COMPRESSION="zstd"
+```
+
+### compressionLevel
+
+This flag sets the compression level. The default value is -1.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "compressionLevel": 5
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+COMPRESSION_LEVEL="5"
+```
+
+### context
+
+This flag specifies the path to the dockerfile build context. The default value is "/workspace/".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "context": "/custom/build/context"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CONTEXT="/custom/build/context"
+```
+
+### contextSubPath
+
+This flag specifies a sub path within the given context.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "contextSubPath": "subdir"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CONTEXT_SUB_PATH="subdir"
+```
+
+### customPlatform
+
+This flag specifies the build platform if different from the current host.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "customPlatform": "linux/arm64"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+CUSTOM_PLATFORM="linux/arm64"
+```
+
+### destination
+
+This flag specifies the registry the final image should be pushed to. Use an array for multiple destinations.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "destination": [
+                "registry.example.com/my-project/my-image:${version}",
+                "registry.example.com/my-project/my-image:latest"
+            ]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+DESTINATION="registry.example.com/my-project/my-image:${version},registry.example.com/my-project/my-image:latest"
+```
+
+### digestFile
+
+This flag specifies a file to save the digest of the built image to.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "digestFile": "/path/to/digest/file"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+DIGEST_FILE="/path/to/digest/file"
+```
+
+### dockerfile
+
+This flag specifies the path to the dockerfile to be built. The default value is "Dockerfile".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "dockerfile": "custom.Dockerfile"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+DOCKERFILE="custom.Dockerfile"
+```
+
+### force
+
+This flag forces building outside of a container.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "force": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+FORCE="true"
+```
+
+### forceBuildMetadata
+
+This flag forces adding metadata layers to the build image.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "forceBuildMetadata": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+FORCE_BUILD_METADATA="true"
+```
+
+### git
+
+This flag specifies git options for cloning if the build context is a git repository.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "git": {
+                "branch": "main",
+                "singleBranch": true,
+                "recurseSubmodules": true
+            }
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+GIT="branch=main,single-branch=true,recurse-submodules=true"
+```
+
+### ignorePath
+
+This flag specifies paths to ignore when taking a snapshot. Use an array for multiple paths.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "ignorePath": ["/path/to/ignore1", "/path/to/ignore2"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IGNORE_PATH="/path/to/ignore1,/path/to/ignore2"
+```
+
+### ignoreVarRun
+
+This flag ignores the /var/run directory when taking an image snapshot. Set it to false to preserve /var/run/ in the destination image. The default value is true.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "ignoreVarRun": false
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IGNORE_VAR_RUN="
+
+false"
+```
+
+### imageDownloadRetry
+
+This flag specifies the number of retries for downloading the remote image.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "imageDownloadRetry": 3
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IMAGE_DOWNLOAD_RETRY="3"
+```
+
+### imageFsExtractRetry
+
+This flag specifies the number of retries for image filesystem extraction.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "imageFsExtractRetry": 3
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IMAGE_FS_EXTRACT_RETRY="3"
+```
+
+### imageNameTagWithDigestFile
+
+This flag specifies a file to save the image name with image tag and digest of the built image to.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "imageNameTagWithDigestFile": "/path/to/image/info/file"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IMAGE_NAME_TAG_WITH_DIGEST_FILE="/path/to/image/info/file"
+```
+
+### imageNameWithDigestFile
+
+This flag specifies a file to save the image name with digest of the built image to.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "imageNameWithDigestFile": "/path/to/image/digest/file"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+IMAGE_NAME_WITH_DIGEST_FILE="/path/to/image/digest/file"
+```
+
+### insecure
+
+This flag enables pushing to an insecure registry using plain HTTP.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "insecure": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+INSECURE="true"
+```
+
+### insecurePull
+
+This flag enables pulling from an insecure registry using plain HTTP.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "insecurePull": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+INSECURE_PULL="true"
+```
+
+### insecureRegistry
+
+This flag specifies insecure registries using plain HTTP to push and pull. Use an array for multiple registries.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "insecureRegistry": ["registry1.example.com", "registry2.example.com"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+INSECURE_REGISTRY="registry1.example.com,registry2.example.com"
+```
+
+### kanikoDir
+
+This flag specifies the path to the kaniko directory. It takes precedence over the KANIKO_DIR environment variable. The default value is "/kaniko".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "kanikoDir": "/custom/kaniko/dir"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+KANIKO_DIR="/custom/kaniko/dir"
+```
+
+### label
+
+This flag sets metadata for an image. Use an array for multiple labels.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "label": ["maintainer=John Doe", "version=1.0.0"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+LABEL="maintainer=John Doe,version=1.0.0"
+```
+
+### logFormat
+
+This flag specifies the log format. Options are "text", "color", or "json". The default value is "color".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "logFormat": "json"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+LOG_FORMAT="json"
+```
+
+### logTimestamp
+
+This flag enables timestamp in log output.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "logTimestamp": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+LOG_TIMESTAMP="true"
+```
+
+### noPush
+
+This flag disables pushing the image to the registry.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "noPush": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+NO_PUSH="true"
+```
+
+### noPushCache
+
+This flag disables pushing the cache layers to the registry.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "noPushCache": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+NO_PUSH_CACHE="true"
+```
+
+### ociLayoutPath
+
+This flag specifies the path to save the OCI image layout of the built image.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "ociLayoutPath": "/path/to/oci/layout"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+OCI_LAYOUT_PATH="/path/to/oci/layout"
+```
+
+### pushIgnoreImmutableTagErrors
+
+This flag, when set to true, ignores known tag immutability errors and finishes the push operation with success.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "pushIgnoreImmutableTagErrors": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+PUSH_IGNORE_IMMUTABLE_TAG_ERRORS="true"
+```
+
+### pushRetry
+
+This flag specifies the number of retries for the push operation.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "pushRetry": 3
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+PUSH_RETRY="3"
+```
+
+### registryCertificate
+
+This flag specifies the certificate to use for TLS communication with the given registry. Expected format is 'my.registry.url=/path/to/the/server/certificate'.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryCertificate": {
+                "my.registry.url": "/path/to/the/server/certificate"
+            }
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REGISTRY_CERTIFICATE="my.registry.url=/path/to/the/server/certificate"
+```
+
+### registryClientCert
+
+This flag specifies the client certificate to use for mutual TLS (mTLS) communication with the given registry. Expected format is 'my.registry.url=/path/to/client/cert,/path/to/client/key'.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryClientCert": {
+                "my.registry.url": "/path/to/client/cert,/path/to/client/key"
+            }
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REGISTRY_CLIENT_CERT="my.registry.url=/path/to/client/cert,/path/to/client/key"
+```
+
+### registryMap
+
+This flag specifies a registry map of mirror to use as pull-through cache instead. Expected format is 'original.registry=new.registry;other-original.registry=other-remap.registry'.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryMap": {
+                "original.registry": "new.registry",
+                "other-original.registry": "other-remap.registry"
+            }
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REGISTRY_MAP="original.registry=new.registry;other-original.registry=other-remap.registry"
+```
+
+### registryMirror
+
+This flag specifies a registry mirror to use as pull-through cache instead of docker.io. Use an array for multiple mirrors.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "registryMirror": ["mirror1.example.com", "mirror2.example.com"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REGISTRY_MIRROR="mirror1.example.com,mirror2.example.com"
+```
+
+### reproducible
+
+This flag strips timestamps out of the image to make it reproducible.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "reproducible": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+REPRODUCIBLE="true"
+```
+
+### singleSnapshot
+
+This flag takes a single snapshot at the end of the build.
+
+\*\*
+
+.releaserc:\*\*
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "singleSnapshot": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SINGLE_SNAPSHOT="true"
+```
+
+### skipDefaultRegistryFallback
+
+This flag, when set, prevents fallback to the default registry if an image is not found on any mirrors (defined with registry-mirror). If registry-mirror is not defined, this flag is ignored.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipDefaultRegistryFallback": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_DEFAULT_REGISTRY_FALLBACK="true"
+```
+
+### skipPushPermissionCheck
+
+This flag skips the check of the push permission.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipPushPermissionCheck": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_PUSH_PERMISSION_CHECK="true"
+```
+
+### skipTlsVerify
+
+This flag enables pushing to an insecure registry ignoring TLS verify.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipTlsVerify": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_TLS_VERIFY="true"
+```
+
+### skipTlsVerifyPull
+
+This flag enables pulling from an insecure registry ignoring TLS verify.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipTlsVerifyPull": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_TLS_VERIFY_PULL="true"
+```
+
+### skipTlsVerifyRegistry
+
+This flag specifies insecure registries ignoring TLS verify to push and pull. Use an array for multiple registries.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipTlsVerifyRegistry": ["registry1.example.com", "registry2.example.com"]
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_TLS_VERIFY_REGISTRY="registry1.example.com,registry2.example.com"
+```
+
+### skipUnusedStages
+
+This flag, when set to true, builds only used stages. Otherwise, it builds all stages by default, even the unnecessary ones until it reaches the target stage / end of Dockerfile.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "skipUnusedStages": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SKIP_UNUSED_STAGES="true"
+```
+
+### snapshotMode
+
+This flag changes the file attributes inspected during snapshotting. The default value is "full".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "snapshotMode": "time"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+SNAPSHOT_MODE="time"
+```
+
+### tarPath
+
+This flag specifies the path to save the image as a tarball instead of pushing.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "tarPath": "/path/to/save/image.tar"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+TAR_PATH="/path/to/save/image.tar"
+```
+
+### target
+
+This flag sets the target build stage to build.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "target": "production"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+TARGET="production"
+```
+
+### useNewRun
+
+This flag enables the use of the experimental run implementation for detecting changes without requiring file system snapshots.
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "useNewRun": true
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+USE_NEW_RUN="true"
+```
+
+### verbosity
+
+This flag sets the log level. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic". The default value is "info".
+
+**.releaserc:**
+
+```json
+{
+    "plugins": [
+        "@bpgeck/semantic-release-kaniko",
+        {
+            "verbosity": "debug"
+        }
+    ]
+}
+```
+
+**Environment variable:**
+
+```shell
+VERBOSITY="debug"
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,8 +158,8 @@ release:
     script:
         - npm ci
         - npx semantic-release
-    only:
-        - main
+    rules:
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 ### CircleCI Example

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,11 +64,22 @@ module.exports = {
 };
 ```
 
-### Environment Variables for Plugin Configuration
+## Environment Variables for Plugin Configuration
 
-In cases where sensitive data or variable configuration is necessary, using environment variables is preferred. This approach is especially beneficial in CI/CD environments where the configuration should not be hardcoded in the `.releaserc` file.
+In cases where sensitive data or variable configuration is necessary, we support providing config values as env vars. This approach is especially beneficial in CI/CD environments where the configuration should not be hardcoded in the `.releaserc` file.
 
-### Example of Configuring with Environment Variables
+The environment variable names are derived from the configuration options by converting the option name to uppercase and prefixing with `KANIKO`. For example, the `destination` option would be set with the `KANIKO_DESTINATION` environment variable.
+
+Anything more complex than a simple key/value pair should be represented as JSON. Some examples:
+
+-   `KANIKO_NO_PUSH=true`
+-   `KANIKO_DOCKERFILE="custom.Dockerfile"`
+-   `KANIKO_DESTINATION='["registry.example.com/my-project/my-image:\${version}","registry.example.com/my-project/my-image:latest"]'`
+-   `KANIKO_REGISTRY_CLIENT_CERT='{"my.first.registry.url":{"cert":"/path/to/first/client/cert","key":"/path/to/first/client/key"},"my.second.registry.url":{"cert":"/path/to/second/client/cert","key":"/path/to/second/client/key"}}'`
+
+Full list of configuration options and examples can be found in the [Configuration](./configuration.md) documentation.
+
+### Environment Variables Example
 
 1. Include the `@bpgeck/semantic-release-kaniko` plugin in your `.releaserc` file:
 
@@ -104,15 +115,9 @@ In cases where sensitive data or variable configuration is necessary, using envi
                 - name: Release
                   run: npx semantic-release
                   env:
-                      DESTINATION: 'registry.example.com/my-project/my-image:${version},registry.example.com/my-project/my-image:latest'
-                      DOCKERFILE: custom.Dockerfile
+                      KANIKO_DESTINATION: '["registry.example.com/my-project/my-image:\${version}","registry.example.com/my-project/my-image:latest"]'
+                      KANIKO_DOCKERFILE: custom.Dockerfile
     ```
-
-### Notes
-
-When using environment variables for list-like values, elements should be separated by commas.
-
-If both environment variables and `.releaserc` configuration are specified for the same key, the `.releaserc` configuration will be preferred.
 
 ## Example Workflows
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -196,13 +196,14 @@ workflows:
 
 ## Private Registry Authorization
 
-You can use environment variables to pass credentials to Kaniko. These environment variables are typically set in your CI/CD environment for security. The two main environment variables used are:
+You can use environment variables to pass credentials to Kaniko. These environment variables are typically set in your CI/CD environment for security. The main environment variables used are:
 
 -   `DOCKER_REGISTRY`: The URL of the Docker registry
 -   `DOCKER_USERNAME`: The username for the Docker registry.
 -   `DOCKER_PASSWORD`: The password or token for the Docker registry.
 
-To configure your GitHub Actions workflow to push images to a private registry, add the `DOCKER_USERNAME` and `DOCKER_PASSWORD` as secrets in your GitHub repository settings. Then, use them in your workflow file:
+
+### GitHub Actions Example
 
 ```yaml
 name: Release

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,229 @@
+# Usage
+
+## Overview
+
+This guide provides usage examples and configurations for the [`.releaserc` file](https://semantic-release.gitbook.io/semantic-release/usage/configuration#configuration-file), demonstrating its use with different formats and Continuous Integration (CI) environments. The `.releaserc` file is used for configuring release settings, including plugins, branches, and other options for the [`semantic-release`](https://semantic-release.gitbook.io/semantic-release) tool, which automates the release process.
+
+## .releaserc
+
+`.releaserc` supports several file formats including JSON, YAML, and JavaScript.
+
+### JSON Example
+
+```json
+{
+    "branches": ["main"],
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        [
+            "@bpgeck/semantic-release-kaniko",
+            {
+                "destination": [
+                    "registry.example.com/my-project/my-image:${version}",
+                    "registry.example.com/my-project/my-image:latest"
+                ],
+                "dockerfile": "custom.Dockerfile"
+            }
+        ]
+    ]
+}
+```
+
+### YAML Example
+
+```yaml
+branches:
+    - main
+plugins:
+    - '@semantic-release/commit-analyzer'
+    - - '@bpgeck/semantic-release-kaniko'
+        - destination:
+            - registry.example.com/my-project/my-image:${version}
+            - registry.example.com/my-project/my-image:latest
+        - dockerfile: custom.Dockerfile
+```
+
+### JavaScript Example
+
+```javascript
+module.exports = {
+    branches: ['main'],
+    plugins: [
+        '@semantic-release/commit-analyzer',
+        [
+            '@bpgeck/semantic-release-kaniko',
+            {
+                destination: [
+                    'registry.example.com/my-project/my-image:${version}',
+                    'registry.example.com/my-project/my-image:latest',
+                ],
+                dockerfile: 'custom.Dockerfile',
+            },
+        ],
+    ],
+};
+```
+
+### Environment Variables for Plugin Configuration
+
+In cases where sensitive data or variable configuration is necessary, using environment variables is preferred. This approach is especially beneficial in CI/CD environments where the configuration should not be hardcoded in the `.releaserc` file.
+
+### Example of Configuring with Environment Variables
+
+1. Include the `@bpgeck/semantic-release-kaniko` plugin in your `.releaserc` file:
+
+    ```json
+    {
+        "branches": ["main"],
+        "plugins": ["@semantic-release/commit-analyzer", "@bpgeck/semantic-release-kaniko"]
+    }
+    ```
+
+2. Define the environment variables in your CI configuration. For instance, in a GitHub Actions workflow:
+
+    ```yaml
+    name: Release
+
+    on:
+        push:
+            branches:
+                - main
+
+    jobs:
+        release:
+            runs-on: ubuntu-latest
+            container:
+                image: ghcr.io/brendangeck/semantic-release-kaniko:latest
+            steps:
+                - name: Checkout code
+                  uses: actions/checkout@v3
+
+                - name: Install dependencies
+                  run: npm i
+
+                - name: Release
+                  run: npx semantic-release
+                  env:
+                      DESTINATION: 'registry.example.com/my-project/my-image:${version},registry.example.com/my-project/my-image:latest'
+                      DOCKERFILE: custom.Dockerfile
+    ```
+
+### Notes
+
+When using environment variables for list-like values, elements should be separated by commas.
+
+If both environment variables and `.releaserc` configuration are specified for the same key, the `.releaserc` configuration will be preferred.
+
+## Example Workflows
+
+Here are some examples showing how to integrate `semantic-release` and the `@bpgeck/semantic-release-kaniko` plugin into various CI/CD pipelines.
+
+### GitHub Actions Workflow Example
+
+```yaml
+name: Release
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/brendangeck/semantic-release-kaniko:latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Release
+              run: npx semantic-release
+```
+
+### GitLab CI Example
+
+```yaml
+stages:
+    - release
+
+release:
+    stage: release
+    image: ghcr.io/brendangeck/semantic-release-kaniko:latest
+    script:
+        - npm ci
+        - npx semantic-release
+    only:
+        - main
+```
+
+### CircleCI Example
+
+```yaml
+version: 2.1
+
+executors:
+    kaniko:
+        docker:
+            - image: ghcr.io/brendangeck/semantic-release-kaniko:latest
+
+jobs:
+    release:
+        executor: kaniko
+        steps:
+            - checkout
+            - run:
+                  name: Install dependencies
+                  command: npm ci
+            - run:
+                  name: Run semantic-release
+                  command: npx semantic-release
+
+workflows:
+    version: 2
+    release:
+        jobs:
+            - release:
+                  filters:
+                      branches:
+                          only: main
+```
+
+## Private Registry Authorization
+
+You can use environment variables to pass credentials to Kaniko. These environment variables are typically set in your CI/CD environment for security. The two main environment variables used are:
+
+-   `DOCKER_REGISTRY`: The URL of the Docker registry
+-   `DOCKER_USERNAME`: The username for the Docker registry.
+-   `DOCKER_PASSWORD`: The password or token for the Docker registry.
+
+To configure your GitHub Actions workflow to push images to a private registry, add the `DOCKER_USERNAME` and `DOCKER_PASSWORD` as secrets in your GitHub repository settings. Then, use them in your workflow file:
+
+```yaml
+name: Release
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        container:
+            image: ghcr.io/brendangeck/semantic-release-kaniko:latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            - name: Release
+              run: npx semantic-release
+              env:
+                  DOCKER_REGISTRY: registry.example.com
+                  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+                  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+```
+
+## Advanced Configuration
+
+For more detailed information on all available configuration flags, refer to the [Configuration](configuration.md) doc.

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -6,29 +6,33 @@ function parseConfig(pluginConfig) {
     const camelToEnvVar = (str) => str.split(/(?=[A-Z])/).join('_').toUpperCase();
 
     const parseIfDefined = (key, parser) => {
-        const value = pluginConfig[key] || process.env[camelToEnvVar(key)];
-        if (value !== undefined) {
-            config[key] = parser ? parser(value) : value;
+        const envVarKey = camelToEnvVar(key);
+        const valueFromEnv = process.env[envVarKey];
+    
+        if (pluginConfig[key] !== undefined) {
+            config[key] = pluginConfig[key];
+        } else if (valueFromEnv !== undefined) {
+            config[key] = parser(valueFromEnv);
         }
     };
-
+    
     parseIfDefined('buildArg', JSON.parse);
     parseIfDefined('cache', toBoolean);
     parseIfDefined('cacheCopyLayers', toBoolean);
-    parseIfDefined('cacheDir');
-    parseIfDefined('cacheRepo');
+    parseIfDefined('cacheDir', toBoolean);
+    parseIfDefined('cacheRepo', toBoolean);
     parseIfDefined('cacheRunLayers', toBoolean);
-    parseIfDefined('cacheTTL');
+    parseIfDefined('cacheTTL', toBoolean);
     parseIfDefined('cleanup', toBoolean);
     parseIfDefined('compressedCaching', toBoolean);
-    parseIfDefined('compression');
+    parseIfDefined('compression', toBoolean);
     parseIfDefined('compressionLevel', parseInt);
-    parseIfDefined('context');
-    parseIfDefined('contextSubPath');
-    parseIfDefined('customPlatform');
+    parseIfDefined('context', toBoolean);
+    parseIfDefined('contextSubPath', toBoolean);
+    parseIfDefined('customPlatform', toBoolean);
     parseIfDefined('destination', parseArrayOrString);
-    parseIfDefined('digestFile');
-    parseIfDefined('dockerfile');
+    parseIfDefined('digestFile', toBoolean);
+    parseIfDefined('dockerfile', toBoolean);
     parseIfDefined('force', toBoolean);
     parseIfDefined('forceBuildMetadata', toBoolean);
     parseIfDefined('git', JSON.parse);
@@ -36,18 +40,18 @@ function parseConfig(pluginConfig) {
     parseIfDefined('ignoreVarRun', toBoolean);
     parseIfDefined('imageDownloadRetry', parseInt);
     parseIfDefined('imageFsExtractRetry', parseInt);
-    parseIfDefined('imageNameTagWithDigestFile');
-    parseIfDefined('imageNameWithDigestFile');
+    parseIfDefined('imageNameTagWithDigestFile', toBoolean);
+    parseIfDefined('imageNameWithDigestFile', toBoolean);
     parseIfDefined('insecure', toBoolean);
     parseIfDefined('insecurePull', toBoolean);
     parseIfDefined('insecureRegistry', parseArrayOrString);
-    parseIfDefined('kanikoDir');
+    parseIfDefined('kanikoDir', toBoolean);
     parseIfDefined('label', JSON.parse);
-    parseIfDefined('logFormat');
+    parseIfDefined('logFormat', toBoolean);
     parseIfDefined('logTimestamp', toBoolean);
     parseIfDefined('noPush', toBoolean);
     parseIfDefined('noPushCache', toBoolean);
-    parseIfDefined('ociLayoutPath');
+    parseIfDefined('ociLayoutPath', toBoolean);
     parseIfDefined('pushIgnoreImmutableTagErrors', toBoolean);
     parseIfDefined('pushRetry', parseInt);
     parseIfDefined('registryCertificate', JSON.parse);
@@ -62,11 +66,11 @@ function parseConfig(pluginConfig) {
     parseIfDefined('skipTlsVerifyPull', toBoolean);
     parseIfDefined('skipTlsVerifyRegistry', parseArrayOrString);
     parseIfDefined('skipUnusedStages', toBoolean);
-    parseIfDefined('snapshotMode');
-    parseIfDefined('tarPath');
-    parseIfDefined('target');
+    parseIfDefined('snapshotMode', toBoolean);
+    parseIfDefined('tarPath', toBoolean);
+    parseIfDefined('target', toBoolean);
     parseIfDefined('useNewRun', toBoolean);
-    parseIfDefined('verbosity');
+    parseIfDefined('verbosity', toBoolean);
 
     return config;
 }
@@ -74,20 +78,20 @@ function parseConfig(pluginConfig) {
 function toKanikoArgs(config) {
     const args = [];
     if (config.buildArg) Object.entries(config.buildArg).forEach(([key, value]) => args.push('--build-arg', `${key}=${value}`));
-    if (config.cache) args.push('--cache=true');
+    if (config.cache !== undefined) args.push(`--cache=${config.cache}`);
     if (config.cacheCopyLayers) args.push('--cache-copy-layers');
     if (config.cacheDir) args.push('--cache-dir', config.cacheDir);
     if (config.cacheRepo) args.push('--cache-repo', config.cacheRepo);
     if (config.cacheRunLayers) args.push('--cache-run-layers');
     if (config.cacheTTL) args.push('--cache-ttl', config.cacheTTL);
     if (config.cleanup) args.push('--cleanup');
-    if (config.compressedCaching !== undefined) args.push('--compressed-caching', config.compressedCaching);
+    if (config.compressedCaching !== undefined) args.push(`--compressed-caching=${config.compressedCaching}`);
     if (config.compression) args.push('--compression', config.compression);
     if (config.compressionLevel)
         args.push('--compression-level', config.compressionLevel.toString());
     if (config.context) args.push('--context', config.context);
     if (config.contextSubPath) args.push('--context-sub-path', config.contextSubPath);
-    if (config.customPlatform) args.push('--customPlatform', config.customPlatform);
+    if (config.customPlatform) args.push('--custom-platform', config.customPlatform);
     if (config.destination)
         args.push(...config.destination.flatMap(dest => ['--destination', dest]));
     if (config.digestFile) args.push('--digest-file', config.digestFile);

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,99 +1,74 @@
 import { parseArrayOrString, toBoolean } from './utils.mjs';
 
-function getConfig(pluginConfig) {
-    return {
-        buildArg: JSON.parse(pluginConfig.buildArg, process.env.BUILD_ARG),
-        cache: toBoolean(pluginConfig.cache || process.env.CACHE),
-        cacheCopyLayers: toBoolean(pluginConfig.cacheCopyLayers || process.env.CACHE_COPY_LAYERS),
-        cacheDir: pluginConfig.cacheDir || process.env.CACHE_DIR,
-        cacheRepo: pluginConfig.cacheRepo || process.env.CACHE_REPO,
-        cacheRunLayers: toBoolean(pluginConfig.cacheRunLayers || process.env.CACHE_RUN_LAYERS),
-        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL,
-        cleanup: toBoolean(pluginConfig.cleanup || process.env.CLEANUP),
-        compressedCaching: toBoolean(
-            pluginConfig.compressedCaching || process.env.COMPRESSED_CACHING
-        ),
-        compression: pluginConfig.compression || process.env.COMPRESSION,
-        compressionLevel: parseInt(pluginConfig.compressionLevel || process.env.COMPRESSION_LEVEL),
-        context: pluginConfig.context || process.env.CONTEXT,
-        contextSubPath: pluginConfig.contextSubPath || process.env.CONTEXT_SUB_PATH,
-        customPlatform: pluginConfig.customPlatform || process.env.CUSTOM_PLATFORM,
-        destination: parseArrayOrString(pluginConfig.destination, process.env.DESTINATION),
-        digestFile: pluginConfig.digestFile || process.env.DIGEST_FILE,
-        dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE,
-        force: toBoolean(pluginConfig.force || process.env.FORCE),
-        forceBuildMetadata: toBoolean(
-            pluginConfig.forceBuildMetadata || process.env.FORCE_BUILD_METADATA
-        ),
-        git: JSON.parse(pluginConfig.git, process.env.GIT),
-        ignorePath: parseArrayOrString(pluginConfig.ignorePath, process.env.IGNORE_PATH),
-        ignoreVarRun: toBoolean(pluginConfig.ignoreVarRun || process.env.IGNORE_VAR_RUN),
-        imageDownloadRetry: parseInt(
-            pluginConfig.imageDownloadRetry || process.env.IMAGE_DOWNLOAD_RETRY
-        ),
-        imageFsExtractRetry: parseInt(
-            pluginConfig.imageFsExtractRetry || process.env.IMAGE_FS_EXTRACT_RETRY
-        ),
-        imageNameTagWithDigestFile:
-            pluginConfig.imageNameTagWithDigestFile || process.env.IMAGE_NAME_TAG_WITH_DIGEST_FILE,
-        imageNameWithDigestFile:
-            pluginConfig.imageNameWithDigestFile || process.env.IMAGE_NAME_WITH_DIGEST_FILE,
-        insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
-        insecurePull: toBoolean(pluginConfig.insecurePull || process.env.INSECURE_PULL),
-        insecureRegistry: parseArrayOrString(
-            pluginConfig.insecureRegistry,
-            process.env.INSECURE_REGISTRY
-        ),
-        kanikoDir: pluginConfig.kanikoDir || process.env.KANIKO_DIR,
-        label: JSON.parse(pluginConfig.label, process.env.LABEL),
-        logFormat: pluginConfig.logFormat || process.env.LOG_FORMAT,
-        logTimestamp: toBoolean(pluginConfig.logTimestamp || process.env.LOG_TIMESTAMP),
-        noPush: toBoolean(pluginConfig.noPush || process.env.NO_PUSH),
-        noPushCache: toBoolean(pluginConfig.noPushCache || process.env.NO_PUSH_CACHE),
-        ociLayoutPath: pluginConfig.ociLayoutPath || process.env.OCI_LAYOUT_PATH,
-        pushIgnoreImmutableTagErrors: toBoolean(
-            pluginConfig.pushIgnoreImmutableTagErrors ||
-                process.env.PUSH_IGNORE_IMMUTABLE_TAG_ERRORS
-        ),
-        pushRetry: parseInt(pluginConfig.pushRetry || process.env.PUSH_RETRY),
-        registryCertificate: JSON.parse(
-            pluginConfig.registryCertificate,
-            process.env.REGISTRY_CERTIFICATE
-        ),
-        registryClientCert: JSON.parse(
-            pluginConfig.registryClientCert,
-            process.env.REGISTRY_CLIENT_CERT
-        ),
-        registryMap: JSON.parse(pluginConfig.registryMap, process.env.KANIKO_REGISTRY_MAP),
-        registryMirror: parseArrayOrString(
-            pluginConfig.registryMirror,
-            process.env.REGISTRY_MIRROR
-        ),
-        reproducible: toBoolean(pluginConfig.reproducible || process.env.REPRODUCIBLE),
-        singleSnapshot: toBoolean(pluginConfig.singleSnapshot || process.env.SINGLE_SNAPSHOT),
-        skipDefaultRegistryFallback: toBoolean(
-            pluginConfig.skipDefaultRegistryFallback || process.env.SKIP_DEFAULT_REGISTRY_FALLBACK
-        ),
-        skipPushPermissionCheck: toBoolean(
-            pluginConfig.skipPushPermissionCheck || process.env.SKIP_PUSH_PERMISSION_CHECK
-        ),
-        skipTlsVerify: toBoolean(pluginConfig.skipTlsVerify || process.env.SKIP_TLS_VERIFY),
-        skipTlsVerifyPull: toBoolean(
-            pluginConfig.skipTlsVerifyPull || process.env.SKIP_TLS_VERIFY_PULL
-        ),
-        skipTlsVerifyRegistry: parseArrayOrString(
-            pluginConfig.skipTlsVerifyRegistry,
-            process.env.SKIP_TLS_VERIFY_REGISTRY
-        ),
-        skipUnusedStages: toBoolean(
-            pluginConfig.skipUnusedStages || process.env.SKIP_UNUSED_STAGES
-        ),
-        snapshotMode: pluginConfig.snapshotMode || process.env.SNAPSHOT_MODE,
-        tarPath: pluginConfig.tarPath || process.env.TAR_PATH,
-        target: pluginConfig.target || process.env.TARGET,
-        useNewRun: toBoolean(pluginConfig.useNewRun || process.env.USE_NEW_RUN),
-        verbosity: pluginConfig.verbosity || process.env.VERBOSITY,
+function parseConfig(pluginConfig) {
+    const config = {};
+
+    const camelToEnvVar = (str) => str.split(/(?=[A-Z])/).join('_').toUpperCase();
+
+    const parseIfDefined = (key, parser) => {
+        const value = pluginConfig[key] || process.env[camelToEnvVar(key)];
+        if (value !== undefined) {
+            config[key] = parser ? parser(value) : value;
+        }
     };
+
+    parseIfDefined('buildArg', JSON.parse);
+    parseIfDefined('cache', toBoolean);
+    parseIfDefined('cacheCopyLayers', toBoolean);
+    parseIfDefined('cacheDir');
+    parseIfDefined('cacheRepo');
+    parseIfDefined('cacheRunLayers', toBoolean);
+    parseIfDefined('cacheTTL');
+    parseIfDefined('cleanup', toBoolean);
+    parseIfDefined('compressedCaching', toBoolean);
+    parseIfDefined('compression');
+    parseIfDefined('compressionLevel', parseInt);
+    parseIfDefined('context');
+    parseIfDefined('contextSubPath');
+    parseIfDefined('customPlatform');
+    parseIfDefined('destination', parseArrayOrString);
+    parseIfDefined('digestFile');
+    parseIfDefined('dockerfile');
+    parseIfDefined('force', toBoolean);
+    parseIfDefined('forceBuildMetadata', toBoolean);
+    parseIfDefined('git', JSON.parse);
+    parseIfDefined('ignorePath', parseArrayOrString);
+    parseIfDefined('ignoreVarRun', toBoolean);
+    parseIfDefined('imageDownloadRetry', parseInt);
+    parseIfDefined('imageFsExtractRetry', parseInt);
+    parseIfDefined('imageNameTagWithDigestFile');
+    parseIfDefined('imageNameWithDigestFile');
+    parseIfDefined('insecure', toBoolean);
+    parseIfDefined('insecurePull', toBoolean);
+    parseIfDefined('insecureRegistry', parseArrayOrString);
+    parseIfDefined('kanikoDir');
+    parseIfDefined('label', JSON.parse);
+    parseIfDefined('logFormat');
+    parseIfDefined('logTimestamp', toBoolean);
+    parseIfDefined('noPush', toBoolean);
+    parseIfDefined('noPushCache', toBoolean);
+    parseIfDefined('ociLayoutPath');
+    parseIfDefined('pushIgnoreImmutableTagErrors', toBoolean);
+    parseIfDefined('pushRetry', parseInt);
+    parseIfDefined('registryCertificate', JSON.parse);
+    parseIfDefined('registryClientCert', JSON.parse);
+    parseIfDefined('registryMap', JSON.parse);
+    parseIfDefined('registryMirror', parseArrayOrString);
+    parseIfDefined('reproducible', toBoolean);
+    parseIfDefined('singleSnapshot', toBoolean);
+    parseIfDefined('skipDefaultRegistryFallback', toBoolean);
+    parseIfDefined('skipPushPermissionCheck', toBoolean);
+    parseIfDefined('skipTlsVerify', toBoolean);
+    parseIfDefined('skipTlsVerifyPull', toBoolean);
+    parseIfDefined('skipTlsVerifyRegistry', parseArrayOrString);
+    parseIfDefined('skipUnusedStages', toBoolean);
+    parseIfDefined('snapshotMode');
+    parseIfDefined('tarPath');
+    parseIfDefined('target');
+    parseIfDefined('useNewRun', toBoolean);
+    parseIfDefined('verbosity');
+
+    return config;
 }
 
 function toKanikoArgs(config) {
@@ -190,4 +165,4 @@ function toKanikoArgs(config) {
     return args;
 }
 
-export { getConfig, toKanikoArgs };
+export { parseConfig, toKanikoArgs };

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,6 +1,6 @@
 import { parseArrayOrString, toBoolean } from './utils.mjs';
 
-export default function getConfig(pluginConfig) {
+function getConfig(pluginConfig) {
     return {
         buildArg: JSON.parse(pluginConfig.buildArg, process.env.BUILD_ARG),
         cache: toBoolean(pluginConfig.cache || process.env.CACHE),
@@ -10,7 +10,9 @@ export default function getConfig(pluginConfig) {
         cacheRunLayers: toBoolean(pluginConfig.cacheRunLayers || process.env.CACHE_RUN_LAYERS),
         cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL,
         cleanup: toBoolean(pluginConfig.cleanup || process.env.CLEANUP),
-        compressedCaching: toBoolean(pluginConfig.compressedCaching || process.env.COMPRESSED_CACHING),
+        compressedCaching: toBoolean(
+            pluginConfig.compressedCaching || process.env.COMPRESSED_CACHING
+        ),
         compression: pluginConfig.compression || process.env.COMPRESSION,
         compressionLevel: parseInt(pluginConfig.compressionLevel || process.env.COMPRESSION_LEVEL),
         context: pluginConfig.context || process.env.CONTEXT,
@@ -20,17 +22,28 @@ export default function getConfig(pluginConfig) {
         digestFile: pluginConfig.digestFile || process.env.DIGEST_FILE,
         dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE,
         force: toBoolean(pluginConfig.force || process.env.FORCE),
-        forceBuildMetadata: toBoolean(pluginConfig.forceBuildMetadata || process.env.FORCE_BUILD_METADATA),
+        forceBuildMetadata: toBoolean(
+            pluginConfig.forceBuildMetadata || process.env.FORCE_BUILD_METADATA
+        ),
         git: JSON.parse(pluginConfig.git, process.env.GIT),
         ignorePath: parseArrayOrString(pluginConfig.ignorePath, process.env.IGNORE_PATH),
         ignoreVarRun: toBoolean(pluginConfig.ignoreVarRun || process.env.IGNORE_VAR_RUN),
-        imageDownloadRetry: parseInt(pluginConfig.imageDownloadRetry || process.env.IMAGE_DOWNLOAD_RETRY),
-        imageFsExtractRetry: parseInt(pluginConfig.imageFsExtractRetry || process.env.IMAGE_FS_EXTRACT_RETRY),
-        imageNameTagWithDigestFile: pluginConfig.imageNameTagWithDigestFile || process.env.IMAGE_NAME_TAG_WITH_DIGEST_FILE,
-        imageNameWithDigestFile: pluginConfig.imageNameWithDigestFile || process.env.IMAGE_NAME_WITH_DIGEST_FILE,
+        imageDownloadRetry: parseInt(
+            pluginConfig.imageDownloadRetry || process.env.IMAGE_DOWNLOAD_RETRY
+        ),
+        imageFsExtractRetry: parseInt(
+            pluginConfig.imageFsExtractRetry || process.env.IMAGE_FS_EXTRACT_RETRY
+        ),
+        imageNameTagWithDigestFile:
+            pluginConfig.imageNameTagWithDigestFile || process.env.IMAGE_NAME_TAG_WITH_DIGEST_FILE,
+        imageNameWithDigestFile:
+            pluginConfig.imageNameWithDigestFile || process.env.IMAGE_NAME_WITH_DIGEST_FILE,
         insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
         insecurePull: toBoolean(pluginConfig.insecurePull || process.env.INSECURE_PULL),
-        insecureRegistry: parseArrayOrString(pluginConfig.insecureRegistry, process.env.INSECURE_REGISTRY),
+        insecureRegistry: parseArrayOrString(
+            pluginConfig.insecureRegistry,
+            process.env.INSECURE_REGISTRY
+        ),
         kanikoDir: pluginConfig.kanikoDir || process.env.KANIKO_DIR,
         label: JSON.parse(pluginConfig.label, process.env.LABEL),
         logFormat: pluginConfig.logFormat || process.env.LOG_FORMAT,
@@ -38,20 +51,43 @@ export default function getConfig(pluginConfig) {
         noPush: toBoolean(pluginConfig.noPush || process.env.NO_PUSH),
         noPushCache: toBoolean(pluginConfig.noPushCache || process.env.NO_PUSH_CACHE),
         ociLayoutPath: pluginConfig.ociLayoutPath || process.env.OCI_LAYOUT_PATH,
-        pushIgnoreImmutableTagErrors: toBoolean(pluginConfig.pushIgnoreImmutableTagErrors || process.env.PUSH_IGNORE_IMMUTABLE_TAG_ERRORS),
+        pushIgnoreImmutableTagErrors: toBoolean(
+            pluginConfig.pushIgnoreImmutableTagErrors ||
+                process.env.PUSH_IGNORE_IMMUTABLE_TAG_ERRORS
+        ),
         pushRetry: parseInt(pluginConfig.pushRetry || process.env.PUSH_RETRY),
-        registryCertificate: JSON.parse(pluginConfig.registryCertificate, process.env.REGISTRY_CERTIFICATE),
-        registryClientCert: JSON.parse(pluginConfig.registryClientCert, process.env.REGISTRY_CLIENT_CERT),
+        registryCertificate: JSON.parse(
+            pluginConfig.registryCertificate,
+            process.env.REGISTRY_CERTIFICATE
+        ),
+        registryClientCert: JSON.parse(
+            pluginConfig.registryClientCert,
+            process.env.REGISTRY_CLIENT_CERT
+        ),
         registryMap: JSON.parse(pluginConfig.registryMap, process.env.KANIKO_REGISTRY_MAP),
-        registryMirror: parseArrayOrString(pluginConfig.registryMirror, process.env.REGISTRY_MIRROR),
+        registryMirror: parseArrayOrString(
+            pluginConfig.registryMirror,
+            process.env.REGISTRY_MIRROR
+        ),
         reproducible: toBoolean(pluginConfig.reproducible || process.env.REPRODUCIBLE),
         singleSnapshot: toBoolean(pluginConfig.singleSnapshot || process.env.SINGLE_SNAPSHOT),
-        skipDefaultRegistryFallback: toBoolean(pluginConfig.skipDefaultRegistryFallback || process.env.SKIP_DEFAULT_REGISTRY_FALLBACK),
-        skipPushPermissionCheck: toBoolean(pluginConfig.skipPushPermissionCheck || process.env.SKIP_PUSH_PERMISSION_CHECK),
+        skipDefaultRegistryFallback: toBoolean(
+            pluginConfig.skipDefaultRegistryFallback || process.env.SKIP_DEFAULT_REGISTRY_FALLBACK
+        ),
+        skipPushPermissionCheck: toBoolean(
+            pluginConfig.skipPushPermissionCheck || process.env.SKIP_PUSH_PERMISSION_CHECK
+        ),
         skipTlsVerify: toBoolean(pluginConfig.skipTlsVerify || process.env.SKIP_TLS_VERIFY),
-        skipTlsVerifyPull: toBoolean(pluginConfig.skipTlsVerifyPull || process.env.SKIP_TLS_VERIFY_PULL),
-        skipTlsVerifyRegistry: parseArrayOrString(pluginConfig.skipTlsVerifyRegistry, process.env.SKIP_TLS_VERIFY_REGISTRY),
-        skipUnusedStages: toBoolean(pluginConfig.skipUnusedStages || process.env.SKIP_UNUSED_STAGES),
+        skipTlsVerifyPull: toBoolean(
+            pluginConfig.skipTlsVerifyPull || process.env.SKIP_TLS_VERIFY_PULL
+        ),
+        skipTlsVerifyRegistry: parseArrayOrString(
+            pluginConfig.skipTlsVerifyRegistry,
+            process.env.SKIP_TLS_VERIFY_REGISTRY
+        ),
+        skipUnusedStages: toBoolean(
+            pluginConfig.skipUnusedStages || process.env.SKIP_UNUSED_STAGES
+        ),
         snapshotMode: pluginConfig.snapshotMode || process.env.SNAPSHOT_MODE,
         tarPath: pluginConfig.tarPath || process.env.TAR_PATH,
         target: pluginConfig.target || process.env.TARGET,
@@ -59,3 +95,99 @@ export default function getConfig(pluginConfig) {
         verbosity: pluginConfig.verbosity || process.env.VERBOSITY,
     };
 }
+
+function toKanikoArgs(config) {
+    const args = [];
+    if (config.buildArg) Object.entries(config.buildArg).forEach(([key, value]) => args.push('--build-arg', `${key}=${value}`));
+    if (config.cache) args.push('--cache=true');
+    if (config.cacheCopyLayers) args.push('--cache-copy-layers');
+    if (config.cacheDir) args.push('--cache-dir', config.cacheDir);
+    if (config.cacheRepo) args.push('--cache-repo', config.cacheRepo);
+    if (config.cacheRunLayers) args.push('--cache-run-layers');
+    if (config.cacheTTL) args.push('--cache-ttl', config.cacheTTL);
+    if (config.cleanup) args.push('--cleanup');
+    if (config.compressedCaching !== undefined) args.push('--compressed-caching', config.compressedCaching);
+    if (config.compression) args.push('--compression', config.compression);
+    if (config.compressionLevel)
+        args.push('--compression-level', config.compressionLevel.toString());
+    if (config.context) args.push('--context', config.context);
+    if (config.contextSubPath) args.push('--context-sub-path', config.contextSubPath);
+    if (config.customPlatform) args.push('--customPlatform', config.customPlatform);
+    if (config.destination)
+        args.push(...config.destination.flatMap(dest => ['--destination', dest]));
+    if (config.digestFile) args.push('--digest-file', config.digestFile);
+    if (config.dockerfile) args.push('--dockerfile', config.dockerfile);
+    if (config.force) args.push('--force');
+    if (config.forceBuildMetadata) args.push('--force-build-metadata');
+    if (config.git) {
+        const gitArgs = Object.entries(config.git)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(',');
+        args.push('--git', gitArgs);
+    }
+    if (config.ignorePath) config.ignorePath.forEach(path => args.push('--ignore-path', path));
+    if (config.ignoreVarRun) args.push('--ignore-var-run');
+    if (config.imageDownloadRetry)
+        args.push('--image-download-retry', config.imageDownloadRetry.toString());
+    if (config.imageFsExtractRetry)
+        args.push('--image-fs-extract-retry', config.imageFsExtractRetry.toString());
+    if (config.imageNameTagWithDigestFile)
+        args.push('--image-name-tag-with-digest-file', config.imageNameTagWithDigestFile);
+    if (config.imageNameWithDigestFile)
+        args.push('--image-name-with-digest-file', config.imageNameWithDigestFile);
+    if (config.insecure) args.push('--insecure');
+    if (config.insecurePull) args.push('--insecure-pull');
+    if (config.insecureRegistry)
+        config.insecureRegistry.forEach(registry => args.push('--insecure-registry', registry));
+    if (config.kanikoDir) args.push('--kaniko-dir', config.kanikoDir);
+    if (config.label)
+        Object.entries(config.label).forEach(([key, value]) =>
+            args.push('--label', `${key}=${value}`)
+        );
+    if (config.logFormat) args.push('--log-format', config.logFormat);
+    if (config.logTimestamp) args.push('--log-timestamp');
+    if (config.noPush) args.push('--no-push');
+    if (config.noPushCache) args.push('--no-push-cache');
+    if (config.ociLayoutPath) args.push('--oci-layout-path', config.ociLayoutPath);
+    if (config.pushIgnoreImmutableTagErrors) args.push('--push-ignore-immutable-tag-errors');
+    if (config.pushRetry) args.push('--push-retry', config.pushRetry.toString());
+    if (config.registryCertificate)
+        Object.entries(config.registryCertificate).forEach(([key, value]) =>
+            args.push('--registry-certificate', `${key}=${value}`)
+        );
+    if (config.registryClientCert)
+        Object.entries(config.registryClientCert).forEach(([key, value]) =>
+            args.push('--registry-client-cert', `${key}=${value.cert},${value.key}`)
+        );
+    if (config.registryMap) {
+        const registryMapArgs = config.registryMap
+            .map(map => Object.entries(map)
+                .map(([original, remapped]) => `${original}=${remapped}`)
+                .join(';')
+            )
+            .join(';');
+        args.push('--registry-map', registryMapArgs);
+    }
+    if (config.registryMirror)
+        config.registryMirror.forEach(mirror => args.push('--registry-mirror', mirror));
+    if (config.reproducible) args.push('--reproducible');
+    if (config.singleSnapshot) args.push('--single-snapshot');
+    if (config.skipDefaultRegistryFallback) args.push('--skip-default-registry-fallback');
+    if (config.skipPushPermissionCheck) args.push('--skip-push-permission-check');
+    if (config.skipTlsVerify) args.push('--skip-tls-verify');
+    if (config.skipTlsVerifyPull) args.push('--skip-tls-verify-pull');
+    if (config.skipTlsVerifyRegistry)
+        config.skipTlsVerifyRegistry.forEach(registry =>
+            args.push('--skip-tls-verify-registry', registry)
+        );
+    if (config.skipUnusedStages) args.push('--skip-unused-stages');
+    if (config.snapshotMode) args.push('--snapshot-mode', config.snapshotMode);
+    if (config.tarPath) args.push('--tar-path', config.tarPath);
+    if (config.target) args.push('--target', config.target);
+    if (config.useNewRun) args.push('--use-new-run');
+    if (config.verbosity) args.push('--verbosity', config.verbosity);
+
+    return args;
+}
+
+export { getConfig, toKanikoArgs };

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,34 +1,61 @@
-/**
- * Utility function to convert environment variable string to boolean.
- * @param {string} value - The environment variable value.
- * @returns {boolean} - The boolean representation of the value.
- */
-function toBoolean(value) {
-    if (typeof value === 'string') {
-        return value.toLowerCase() === 'true' || value === '1';
-    }
-    return Boolean(value);
-}
+import { parseArrayOrString, toBoolean } from './utils.mjs';
 
-/**
- * Parses the configuration from pluginConfig and environment variables.
- * @param {Object} pluginConfig - The plugin configuration.
- * @returns {Object} - The parsed configuration.
- */
-function parseConfig(pluginConfig) {
+export default function getConfig(pluginConfig) {
     return {
-        image: pluginConfig.image || process.env.IMAGE,
-        tags: pluginConfig.tags || (process.env.TAGS ? process.env.TAGS.split(',') : []),
-        dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE || 'Dockerfile',
-        registry: pluginConfig.registry || process.env.REGISTRY,
-        username: pluginConfig.username || process.env.DOCKER_USERNAME,
-        password: pluginConfig.password || process.env.DOCKER_PASSWORD,
-        insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
-        target: pluginConfig.target || process.env.TARGET,
+        buildArg: JSON.parse(pluginConfig.buildArg, process.env.BUILD_ARG),
         cache: toBoolean(pluginConfig.cache || process.env.CACHE),
-        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL || '24h',
+        cacheCopyLayers: toBoolean(pluginConfig.cacheCopyLayers || process.env.CACHE_COPY_LAYERS),
+        cacheDir: pluginConfig.cacheDir || process.env.CACHE_DIR,
+        cacheRepo: pluginConfig.cacheRepo || process.env.CACHE_REPO,
+        cacheRunLayers: toBoolean(pluginConfig.cacheRunLayers || process.env.CACHE_RUN_LAYERS),
+        cacheTTL: pluginConfig.cacheTTL || process.env.CACHE_TTL,
+        cleanup: toBoolean(pluginConfig.cleanup || process.env.CLEANUP),
+        compressedCaching: toBoolean(pluginConfig.compressedCaching || process.env.COMPRESSED_CACHING),
+        compression: pluginConfig.compression || process.env.COMPRESSION,
+        compressionLevel: parseInt(pluginConfig.compressionLevel || process.env.COMPRESSION_LEVEL),
+        context: pluginConfig.context || process.env.CONTEXT,
+        contextSubPath: pluginConfig.contextSubPath || process.env.CONTEXT_SUB_PATH,
+        customPlatform: pluginConfig.customPlatform || process.env.CUSTOM_PLATFORM,
+        destination: parseArrayOrString(pluginConfig.destination, process.env.DESTINATION),
+        digestFile: pluginConfig.digestFile || process.env.DIGEST_FILE,
+        dockerfile: pluginConfig.dockerfile || process.env.DOCKERFILE,
+        force: toBoolean(pluginConfig.force || process.env.FORCE),
+        forceBuildMetadata: toBoolean(pluginConfig.forceBuildMetadata || process.env.FORCE_BUILD_METADATA),
+        git: JSON.parse(pluginConfig.git, process.env.GIT),
+        ignorePath: parseArrayOrString(pluginConfig.ignorePath, process.env.IGNORE_PATH),
+        ignoreVarRun: toBoolean(pluginConfig.ignoreVarRun || process.env.IGNORE_VAR_RUN),
+        imageDownloadRetry: parseInt(pluginConfig.imageDownloadRetry || process.env.IMAGE_DOWNLOAD_RETRY),
+        imageFsExtractRetry: parseInt(pluginConfig.imageFsExtractRetry || process.env.IMAGE_FS_EXTRACT_RETRY),
+        imageNameTagWithDigestFile: pluginConfig.imageNameTagWithDigestFile || process.env.IMAGE_NAME_TAG_WITH_DIGEST_FILE,
+        imageNameWithDigestFile: pluginConfig.imageNameWithDigestFile || process.env.IMAGE_NAME_WITH_DIGEST_FILE,
+        insecure: toBoolean(pluginConfig.insecure || process.env.INSECURE),
+        insecurePull: toBoolean(pluginConfig.insecurePull || process.env.INSECURE_PULL),
+        insecureRegistry: parseArrayOrString(pluginConfig.insecureRegistry, process.env.INSECURE_REGISTRY),
         kanikoDir: pluginConfig.kanikoDir || process.env.KANIKO_DIR,
+        label: JSON.parse(pluginConfig.label, process.env.LABEL),
+        logFormat: pluginConfig.logFormat || process.env.LOG_FORMAT,
+        logTimestamp: toBoolean(pluginConfig.logTimestamp || process.env.LOG_TIMESTAMP),
+        noPush: toBoolean(pluginConfig.noPush || process.env.NO_PUSH),
+        noPushCache: toBoolean(pluginConfig.noPushCache || process.env.NO_PUSH_CACHE),
+        ociLayoutPath: pluginConfig.ociLayoutPath || process.env.OCI_LAYOUT_PATH,
+        pushIgnoreImmutableTagErrors: toBoolean(pluginConfig.pushIgnoreImmutableTagErrors || process.env.PUSH_IGNORE_IMMUTABLE_TAG_ERRORS),
+        pushRetry: parseInt(pluginConfig.pushRetry || process.env.PUSH_RETRY),
+        registryCertificate: JSON.parse(pluginConfig.registryCertificate, process.env.REGISTRY_CERTIFICATE),
+        registryClientCert: JSON.parse(pluginConfig.registryClientCert, process.env.REGISTRY_CLIENT_CERT),
+        registryMap: JSON.parse(pluginConfig.registryMap, process.env.KANIKO_REGISTRY_MAP),
+        registryMirror: parseArrayOrString(pluginConfig.registryMirror, process.env.REGISTRY_MIRROR),
+        reproducible: toBoolean(pluginConfig.reproducible || process.env.REPRODUCIBLE),
+        singleSnapshot: toBoolean(pluginConfig.singleSnapshot || process.env.SINGLE_SNAPSHOT),
+        skipDefaultRegistryFallback: toBoolean(pluginConfig.skipDefaultRegistryFallback || process.env.SKIP_DEFAULT_REGISTRY_FALLBACK),
+        skipPushPermissionCheck: toBoolean(pluginConfig.skipPushPermissionCheck || process.env.SKIP_PUSH_PERMISSION_CHECK),
+        skipTlsVerify: toBoolean(pluginConfig.skipTlsVerify || process.env.SKIP_TLS_VERIFY),
+        skipTlsVerifyPull: toBoolean(pluginConfig.skipTlsVerifyPull || process.env.SKIP_TLS_VERIFY_PULL),
+        skipTlsVerifyRegistry: parseArrayOrString(pluginConfig.skipTlsVerifyRegistry, process.env.SKIP_TLS_VERIFY_REGISTRY),
+        skipUnusedStages: toBoolean(pluginConfig.skipUnusedStages || process.env.SKIP_UNUSED_STAGES),
+        snapshotMode: pluginConfig.snapshotMode || process.env.SNAPSHOT_MODE,
+        tarPath: pluginConfig.tarPath || process.env.TAR_PATH,
+        target: pluginConfig.target || process.env.TARGET,
+        useNewRun: toBoolean(pluginConfig.useNewRun || process.env.USE_NEW_RUN),
+        verbosity: pluginConfig.verbosity || process.env.VERBOSITY,
     };
 }
-
-export { toBoolean, parseConfig };

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -3,7 +3,7 @@ import { parseArrayOrString, toBoolean } from './utils.mjs';
 function parseConfig(pluginConfig) {
     const config = {};
 
-    const camelToEnvVar = (str) => str.split(/(?=[A-Z])/).join('_').toUpperCase();
+    const camelToEnvVar = (str) => 'KANIKO_' + str.split(/(?=[A-Z])/).join('_').toUpperCase();
 
     const parseIfDefined = (key, parser) => {
         const envVarKey = camelToEnvVar(key);

--- a/lib/publish.mjs
+++ b/lib/publish.mjs
@@ -1,5 +1,5 @@
 import { execa } from 'execa';
-import { parseConfig } from './config.mjs';
+import { parseConfig, toKanikoArgs } from './config.mjs';
 
 async function publish(pluginConfig, context) {
     const { logger, nextRelease } = context;
@@ -7,40 +7,18 @@ async function publish(pluginConfig, context) {
     // Parse configuration
     const config = parseConfig(pluginConfig);
 
-    if (!config.image || !config.registry) {
-        throw new Error('Both image and registry must be specified.');
-    }
-
-    const destinations = config.tags.map(tag => {
-        const tagName = `${config.image}:${tag === '${version}' ? nextRelease.version : tag}`;
-        return `${config.registry}/${tagName}`;
+    config.destination = config.destination.map(destination => {
+        return destination.replace('${version}', nextRelease.version);
     });
 
-    logger.log(`Building and pushing Docker image with the following destinations: ${destinations.join(', ')}`);
+    logger.log(`Building and pushing Docker image with the following destinations: ${config.destination.join(', ')}`);
 
     try {
-        const kanikoArgs = [
-            '--dockerfile',
-            config.dockerfile,
-            '--context',
-            '.',
-            ...destinations.flatMap(destination => ['--destination', destination])
-        ];
-
-        if (config.target) kanikoArgs.push('--target', config.target); // Add target if specified
-        if (config.insecure) kanikoArgs.push('--insecure'); // Set to insecure mode if specified
-        if (config.cache) kanikoArgs.push('--cache'); // Enable cache if specified
-        if (config.cache && config.cacheTTL) kanikoArgs.push('--cache-ttl', config.cacheTTL); // Set cache TTL if specified
-        if (config.kanikoDir) kanikoArgs.push('--kaniko-dir', config.kanikoDir); // Set an alternative staging folder for Kaniko
-
-        const env = {};
-        if (config.username) env.DOCKER_USERNAME = config.username;
-        if (config.password) env.DOCKER_PASSWORD = config.password;
-
-        await execa('/kaniko/executor', kanikoArgs, { env });
-        logger.log(`Successfully built and pushed images: ${destinations.join(', ')}`);
+        const kanikoArgs = toKanikoArgs(config);
+        await execa('/kaniko/executor', kanikoArgs);
+        logger.log(`Successfully built and pushed images: ${config.destination.join(', ')}`);
     } catch (error) {
-        logger.error(`Failed to build and push images: ${destinations.join(', ')}`);
+        logger.error(`Failed to build and push images: ${config.destination.join(', ')}`);
         throw error;
     }
 

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -1,0 +1,20 @@
+export function parseArrayOrString(value, envVar) {
+    if (Array.isArray(value)) {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return [value];
+    }
+    if (envVar) {
+        try {
+            return JSON.parse(envVar);
+        } catch (error) {
+            return [envVar];
+        }
+    }
+    return undefined;
+}
+
+export function toBoolean(value) {
+    return value === true || value === 'true';
+}

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -5,12 +5,9 @@ import { parseConfig } from './config.mjs';
 
 // Error messages
 const ERRORS = {
-    MISSING_KANIKO: 'Kaniko is not installed or not in PATH',
-    MISSING_REGISTRY: 'Missing Docker registry in configuration',
-    MISSING_IMAGE: 'Missing Docker image name in configuration',
-    MISSING_TAGS: 'Missing image tags in configuration',
-    DOCKERFILE_NOT_FOUND: path => `Dockerfile not found at ${path}`,
-    REGISTRY_AUTH: 'Not authenticated with Docker registry',
+    MISSING_KANIKO: '/kaniko/executor is not found in PATH. Are you using a container with kaniko installed?',
+    MISSING_DOCKERFILE: path => `Dockerfile not found at ${path}`,
+    MISSING_DESTINATION: 'You must set at least one destination',
 };
 
 /**
@@ -26,11 +23,29 @@ async function verifyConditions(pluginConfig, context) {
         await execa('/kaniko/executor', ['version']);
         logger.info('Kaniko is installed and accessible.');
     } catch (_error) {
-        throw new SemanticReleaseError(ERRORS.MISSING_KANIKO, 'EKANIKOOMISSING');
+        throw new SemanticReleaseError(ERRORS.MISSING_KANIKO, 'EMISSINGKANIKO');
     }
 
     // Parse configuration
     const config = parseConfig(pluginConfig);
+
+    // Check if Dockerfile exists at specified path
+    if (!config.dockerfile) {
+        logger.info('Dockerfile path is not set, defaulting to Dockerfile');
+    }
+    const dockerfilePath = config.dockerfile || 'Dockerfile';
+
+    try {
+        await fs.access(dockerfilePath);
+        logger.info(`Dockerfile found at ${dockerfilePath}`);
+    } catch (_error) {
+        throw new SemanticReleaseError(ERRORS.MISSING_DOCKERFILE(dockerfilePath), 'EMISSINGDOCKERFILE');
+    }
+
+    // Check if destination is set
+    if (!config.destination) {
+        throw new SemanticReleaseError(ERRORS.MISSING_DESTINATION, 'EMISSINGDESTINATION');
+    }
 
     logger.log('semantic-release-kaniko plugin configuration verified.');
 }

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -32,28 +32,6 @@ async function verifyConditions(pluginConfig, context) {
     // Parse configuration
     const config = parseConfig(pluginConfig);
 
-    // Verify required configuration fields
-    if (!config.registry) {
-        throw new SemanticReleaseError(ERRORS.MISSING_REGISTRY, 'EMISSINGREGISTRY');
-    }
-    if (!config.image) {
-        throw new SemanticReleaseError(ERRORS.MISSING_IMAGE, 'EMISSINGIMAGE');
-    }
-    if (!Array.isArray(config.tags) || config.tags.length === 0) {
-        throw new SemanticReleaseError(ERRORS.MISSING_TAGS, 'EMISSINGTAGS');
-    }
-
-    // Check if Dockerfile exists
-    try {
-        await fs.access(config.dockerfile);
-        logger.info(`Dockerfile found at ${config.dockerfile}`);
-    } catch (_error) {
-        throw new SemanticReleaseError(
-            ERRORS.DOCKERFILE_NOT_FOUND(config.dockerfile),
-            'EDOCKERFILENOTFOUND'
-        );
-    }
-
     logger.log('semantic-release-kaniko plugin configuration verified.');
 }
 

--- a/lib/verifyConditions.mjs
+++ b/lib/verifyConditions.mjs
@@ -23,29 +23,37 @@ async function verifyConditions(pluginConfig, context) {
         await execa('/kaniko/executor', ['version']);
         logger.info('Kaniko is installed and accessible.');
     } catch (_error) {
+        logger.info('Failed to verify Kaniko installation.');
         throw new SemanticReleaseError(ERRORS.MISSING_KANIKO, 'EMISSINGKANIKO');
     }
+    logger.info('Kaniko installation check passed.');
 
     // Parse configuration
     const config = parseConfig(pluginConfig);
+    logger.info('Configuration parsed.');
 
     // Check if Dockerfile exists at specified path
     if (!config.dockerfile) {
         logger.info('Dockerfile path is not set, defaulting to Dockerfile');
     }
     const dockerfilePath = config.dockerfile || 'Dockerfile';
+    logger.info(`Dockerfile path set to ${dockerfilePath}`);
 
     try {
         await fs.access(dockerfilePath);
         logger.info(`Dockerfile found at ${dockerfilePath}`);
     } catch (_error) {
+        logger.info(`Dockerfile not found at ${dockerfilePath}`);
         throw new SemanticReleaseError(ERRORS.MISSING_DOCKERFILE(dockerfilePath), 'EMISSINGDOCKERFILE');
     }
+    logger.info('Dockerfile existence check passed.');
 
     // Check if destination is set
     if (!config.destination) {
+        logger.info('Destination is not set.');
         throw new SemanticReleaseError(ERRORS.MISSING_DESTINATION, 'EMISSINGDESTINATION');
     }
+    logger.info('Destination is set.');
 
     logger.log('semantic-release-kaniko plugin configuration verified.');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "eslint-plugin-prettier": "^5.2.1",
                 "globals": "^15.9.0",
                 "mocha": "^10.7.0",
+                "prettier": "^3.3.3",
                 "semantic-release": "^24.0.0"
             },
             "engines": {
@@ -6237,6 +6238,22 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/prettier-linter-helpers": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
@@ -11693,6 +11710,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "prettier": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true
         },
         "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "globals": "^15.9.0",
         "mocha": "^10.7.0",
+        "prettier": "^3.3.3",
         "semantic-release": "^24.0.0"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "node": ">=20.8.1"
     },
     "scripts": {
-        "test": "docker compose up --attach test-runner --abort-on-container-exit",
+        "test": "docker compose build --no-cache && docker compose up --attach test-suite-prepare-publish --abort-on-container-exit && docker compose logs test-suite-verify-conditions",
         "lint": "eslint ."
     },
     "keywords": [

--- a/tst/integ/preparePublish.test.js
+++ b/tst/integ/preparePublish.test.js
@@ -1,16 +1,15 @@
-import { prepare } from '../../lib/prepare.mjs';
 import { publish } from '../../lib/publish.mjs';
 import assert from 'assert';
 
 // Merging prepare and publish into the same test suite to guarantee they run in order
-describe('Prepare and Publish', function () {
+describe('Comprehensive Test with All Arguments', function () {
     this.timeout(600000); // 10 minute timeout
 
     let context;
     let pluginConfig;
 
     beforeEach(() => {
-        // Mock context and pluginConfig
+        // Mock context
         context = {
             logger: console,
             nextRelease: {
@@ -18,34 +17,76 @@ describe('Prepare and Publish', function () {
             },
         };
 
+        // Comprehensive configuration with all possible flags
         pluginConfig = {
-            registry: 'mock-registry:5000',
-            image: 'my-project/my-image',
-            tags: ['${version}', 'latest'],
+            buildArg: { TEST_ARG: 'TEST' },
+            cache: true,
+            cacheDir: '/path/to/cache',
+            cacheRepo: 'mock-cache-repo',
+            cacheRunLayers: true,
+            cacheTTL: '24h',
+            cleanup: true,
+            compressedCaching: true,
+            compression: 'gzip',
+            compressionLevel: 6,
+            context: '/',
+            contextSubPath: 'app',
+            customPlatform: 'linux/amd64',
+            destination: [
+                'mock-registry:5000/my-project/my-image:${version}',
+                'mock-registry:5000/my-project/my-image:latest',
+            ],
+            digestFile: '/path/to/digest/file',
             dockerfile: 'tst/integ/resources/test.Dockerfile',
+            force: true,
+            forceBuildMetadata: true,
+            git: { branch: 'main', commit: 'abc123' },
+            ignorePath: ['/path/to/ignore'],
+            ignoreVarRun: true,
+            imageDownloadRetry: 3,
+            imageFsExtractRetry: 3,
+            imageNameTagWithDigestFile: '/path/to/image-name-tag-with-digest-file',
+            imageNameWithDigestFile: '/path/to/image-name-with-digest-file',
+            insecure: true,
+            insecurePull: true,
+            insecureRegistry: ['mock-registry:5000'],
+            kanikoDir: '/kaniko/executor',
+            label: { maintainer: 'test-user' },
+            logFormat: 'json',
+            logTimestamp: true,
+            noPush: false,
+            noPushCache: false,
+            ociLayoutPath: '/output/ociLayoutPath',
+            pushIgnoreImmutableTagErrors: true,
+            pushRetry: 3,
+            registryCertificate: { cert: '/path/to/cert', key: '/path/to/key' },
+            registryClientCert: { cert: '/path/to/client/cert', key: '/path/to/client/key' },
+            registryMap: [{ 'original-registry': 'remapped-registry' }],
+            registryMirror: ['mock-registry-mirror:5000'],
+            reproducible: true,
+            singleSnapshot: true,
+            skipDefaultRegistryFallback: true,
+            skipPushPermissionCheck: true,
+            skipTlsVerify: true,
+            skipTlsVerifyPull: true,
+            skipTlsVerifyRegistry: ['mock-registry:5000'],
+            skipUnusedStages: true,
+            snapshotMode: 'full',
+            tarPath: '/path/to/tar',
+            target: 'final',
+            useNewRun: true,
+            verbosity: 'info',
             username: 'test-user',
             password: 'test-password',
-            insecure: true,
         };
     });
 
-    it('should prepare Docker images', async () => {
-        try {
-            await prepare(pluginConfig, context);
-
-            // Assume no error means success
-        } catch (error) {
-            assert.fail(`Failed to prepare Docker images: ${error.message}`);
-        }
-    });
-
-    it('should push Docker images to the registry', async () => {
+    it('should execute publish with all configuration parameters successfully', async () => {
         try {
             await publish(pluginConfig, context);
-
             // Assume no error means success
         } catch (error) {
-            assert.fail(`Failed to push Docker images: ${error.message}`);
+            assert.fail(`Failed to publish with all arguments: ${error.stack}`);
         }
     });
 });

--- a/tst/integ/resources/test.Dockerfile
+++ b/tst/integ/resources/test.Dockerfile
@@ -1,8 +1,20 @@
-# Use a minimal base image
-FROM scratch
+# First stage: Build stage
+FROM scratch AS build
 
-# Set a simple environment variable
-ENV TEST_ENV="semantic-release-kaniko test"
+# Create a file in the first stage
+# Since 'scratch' doesn't have utilities, simulate by using ARG
+ARG BUILD_CONTENT="This is content from the build stage"
+ENV BUILD_OUTPUT="${BUILD_CONTENT}"
+
+# Second stage: Final stage
+FROM scratch AS final
+
+# ARG used in the final stage
+ARG TEST_ARG
+
+# Set a simple environment variable in the final stage
+ENV TEST_ENV="semantic-release-kaniko"
+ENV FINAL_CONTENT="${BUILD_OUTPUT}"
 
 # Define an empty CMD
 CMD []

--- a/tst/integ/verifyConditions.test.js
+++ b/tst/integ/verifyConditions.test.js
@@ -64,8 +64,8 @@ describe('Verify Conditions', function () {
     });
 
     it('should verify required environment variables are set', async () => {
-        process.env.DESTINATION = 'registry.example.com/my-image:${version}';
-        process.env.DOCKERFILE = 'tst/integ/resources/test.Dockerfile';
+        process.env.KANIKO_DESTINATION = 'registry.example.com/my-image:${version}';
+        process.env.KANIKO_DOCKERFILE = 'tst/integ/resources/test.Dockerfile';
         const pluginConfig = {};
         await executeVerification(pluginConfig);
     });

--- a/tst/integ/verifyConditions.test.js
+++ b/tst/integ/verifyConditions.test.js
@@ -19,8 +19,10 @@ describe('Verify Conditions', function () {
 
     const executeVerification = async (pluginConfig, expectedError) => {
         if (expectedError) {
-            await assert.rejects(verifyConditions(pluginConfig, { logger: console }), 
-                error => error instanceof SemanticReleaseError && error.code === expectedError);
+            await assert.rejects(
+                verifyConditions(pluginConfig, { logger: console }),
+                error => error instanceof SemanticReleaseError && error.code === expectedError
+            );
         } else {
             await assert.doesNotReject(verifyConditions(pluginConfig, { logger: console }));
         }
@@ -46,12 +48,18 @@ describe('Verify Conditions', function () {
     });
 
     it('should fail when Dockerfile does not exist', async () => {
-        const pluginConfig = { destination: ['registry.example.com/my-image:${version}'], dockerfile: 'NonExistentDockerfile' };
+        const pluginConfig = {
+            destination: ['registry.example.com/my-image:${version}'],
+            dockerfile: 'NonExistentDockerfile',
+        };
         await executeVerification(pluginConfig, 'EMISSINGDOCKERFILE');
     });
 
     it('should pass with valid configuration', async () => {
-        const pluginConfig = { destination: ['registry.example.com/my-image:${version}'], dockerfile: 'tst/integ/resources/test.Dockerfile' };
+        const pluginConfig = {
+            destination: ['registry.example.com/my-image:${version}'],
+            dockerfile: 'tst/integ/resources/test.Dockerfile',
+        };
         await executeVerification(pluginConfig);
     });
 

--- a/tst/integ/verifyConditions.test.js
+++ b/tst/integ/verifyConditions.test.js
@@ -1,17 +1,8 @@
 import { verifyConditions } from '../../lib/verifyConditions.mjs';
 import assert from 'assert';
 import SemanticReleaseError from '@semantic-release/error';
-
-const validConfig = {
-    image: 'test-project/test-image',
-    tags: ['latest', '${version}'],
-    registry: 'mock-registry:5000',
-    dockerfile: 'Dockerfile',
-};
-
-const context = {
-    logger: console,
-};
+import fs from 'fs';
+import path from 'path';
 
 describe('Verify Conditions', function () {
     this.timeout(20000);
@@ -26,49 +17,48 @@ describe('Verify Conditions', function () {
         process.env = originalEnv;
     });
 
-    it('should fail if Dockerfile is missing', async () => {
-        const invalidConfig = { ...validConfig, dockerfile: 'NonExistentDockerfile' };
-        await assert.rejects(verifyConditions(invalidConfig, context), error => {
-            assert(error instanceof SemanticReleaseError);
-            assert.strictEqual(error.code, 'EDOCKERFILENOTFOUND');
-            return true;
-        });
+    const executeVerification = async (pluginConfig, expectedError) => {
+        if (expectedError) {
+            await assert.rejects(verifyConditions(pluginConfig, { logger: console }), 
+                error => error instanceof SemanticReleaseError && error.code === expectedError);
+        } else {
+            await assert.doesNotReject(verifyConditions(pluginConfig, { logger: console }));
+        }
+    };
+
+    it('should fail when Kaniko is not installed', async () => {
+        const kanikoExecutorPath = '/kaniko/executor';
+        const invalidKanikoPath = '/kaniko/executor_invalid';
+
+        fs.mkdirSync(path.dirname(invalidKanikoPath), { recursive: true });
+        fs.renameSync(kanikoExecutorPath, invalidKanikoPath);
+
+        try {
+            await executeVerification({}, 'EMISSINGKANIKO');
+        } finally {
+            fs.renameSync(invalidKanikoPath, kanikoExecutorPath);
+        }
     });
 
-    it('should fail if registry is missing in configuration', async () => {
-        const invalidConfig = { ...validConfig, registry: null };
-        await assert.rejects(verifyConditions(invalidConfig, context), error => {
-            assert(error instanceof SemanticReleaseError);
-            assert.strictEqual(error.code, 'EMISSINGREGISTRY');
-            return true;
-        });
+    it('should fail when destination is not set', async () => {
+        const pluginConfig = { dockerfile: 'tst/integ/resources/test.Dockerfile' };
+        await executeVerification(pluginConfig, 'EMISSINGDESTINATION');
     });
 
-    it('should fail if image is missing in configuration', async () => {
-        const invalidConfig = { ...validConfig, image: null };
-        await assert.rejects(verifyConditions(invalidConfig, context), error => {
-            assert(error instanceof SemanticReleaseError);
-            assert.strictEqual(error.code, 'EMISSINGIMAGE');
-            return true;
-        });
+    it('should fail when Dockerfile does not exist', async () => {
+        const pluginConfig = { destination: ['registry.example.com/my-image:${version}'], dockerfile: 'NonExistentDockerfile' };
+        await executeVerification(pluginConfig, 'EMISSINGDOCKERFILE');
     });
 
-    it('should fail if tags are missing in configuration', async () => {
-        const invalidConfig = { ...validConfig, tags: [] };
-        await assert.rejects(verifyConditions(invalidConfig, context), error => {
-            assert(error instanceof SemanticReleaseError);
-            assert.strictEqual(error.code, 'EMISSINGTAGS');
-            return true;
-        });
+    it('should pass with valid configuration', async () => {
+        const pluginConfig = { destination: ['registry.example.com/my-image:${version}'], dockerfile: 'tst/integ/resources/test.Dockerfile' };
+        await executeVerification(pluginConfig);
     });
 
-    it('should use environment variables when config is not provided', async () => {
-        process.env.IMAGE = 'env-test-image';
-        process.env.TAGS = 'latest,${version}';
-        process.env.REGISTRY = 'env-registry:5000';
+    it('should verify required environment variables are set', async () => {
+        process.env.DESTINATION = 'registry.example.com/my-image:${version}';
         process.env.DOCKERFILE = 'tst/integ/resources/test.Dockerfile';
-
-        const emptyConfig = {};
-        await verifyConditions(emptyConfig, { logger: console });
+        const pluginConfig = {};
+        await executeVerification(pluginConfig);
     });
 });


### PR DESCRIPTION
- Overhauling how we parse parameters.
- Adding support for all kaniko parameters 1-to-1, directly from their docs: https://github.com/GoogleContainerTools/kaniko/blob/main/README.md
- Rewriting docs to account for full flag support.
- Adding tests for all flags and new verify conditions.