### PR TITLE
fix: handling of complex vars set in env

### DIFF
--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -1,17 +1,30 @@
 export function parseArrayOrString(value, envVar) {
+    const parseValue = (val) => {
+        // Attempt to parse as JSON
+        try {
+            const parsed = JSON.parse(val);
+            if (Array.isArray(parsed)) {
+                return parsed;
+            }
+            return [parsed];
+        } catch (error) {
+            // If not JSON, assume it's a comma-separated list
+            return val.split(',').map(item => item.trim());
+        }
+    };
+
     if (Array.isArray(value)) {
         return value;
     }
+
     if (typeof value === 'string') {
-        return [value];
+        return parseValue(value);
     }
+
     if (envVar) {
-        try {
-            return JSON.parse(envVar);
-        } catch (error) {
-            return [envVar];
-        }
+        return parseValue(envVar);
     }
+
     return undefined;
 }
 

--- a/tst/testConfig.mjs
+++ b/tst/testConfig.mjs
@@ -1,0 +1,97 @@
+import { parseConfig, toKanikoArgs } from '../lib/config.mjs';
+
+// Function to run a test case
+function runTestCase(description, envVars, expectedDest, expectedMirror) {
+    console.log(`\n--- ${description} ---`);
+
+    // Clear environment variables before each test
+    delete process.env.KANIKO_DESTINATION;
+    delete process.env.KANIKO_REGISTRY_MIRROR;
+
+    // Set environment variables for the test
+    if (envVars.destination) {
+        process.env.KANIKO_DESTINATION = envVars.destination;
+    }
+    if (envVars.registryMirror) {
+        process.env.KANIKO_REGISTRY_MIRROR = envVars.registryMirror;
+    }
+
+    // Mock plugin configuration object
+    const pluginConfig = {};
+
+    // Parse configuration
+    const config = parseConfig(pluginConfig);
+
+    // Convert parsed config to Kaniko args
+    const kanikoArgs = toKanikoArgs(config);
+
+    // Output the results
+    console.log('Parsed Config:', config);
+    console.log('Kaniko Args:', kanikoArgs);
+
+    // Assertions (could be replaced with an actual testing framework)
+    if (JSON.stringify(config.destination) !== JSON.stringify(expectedDest)) {
+        console.error('Test failed: destination did not match expected value');
+    } else {
+        console.log('Destination matched expected value');
+    }
+    if (JSON.stringify(config.registryMirror) !== JSON.stringify(expectedMirror)) {
+        console.error('Test failed: registryMirror did not match expected value');
+    } else {
+        console.log('RegistryMirror matched expected value');
+    }
+}
+
+// Test Cases
+runTestCase(
+    'Test with JSON array as environment variable',
+    {
+        destination: '["registry.example.commy-image:${version}","registry.example.commy-image:latest"]',
+        registryMirror: '["mock-registry-mirror:5000"]'
+    },
+    [
+        'registry.example.commy-image:${version}',
+        'registry.example.commy-image:latest'
+    ],
+    ['mock-registry-mirror:5000']
+);
+
+runTestCase(
+    'Test with comma-separated string as environment variable',
+    {
+        destination: 'registry.example.commy-image:${version},registry.example.commy-image:latest',
+        registryMirror: 'mock-registry-mirror:5000'
+    },
+    [
+        'registry.example.commy-image:${version}',
+        'registry.example.commy-image:latest'
+    ],
+    ['mock-registry-mirror:5000']
+);
+
+runTestCase(
+    'Test with single string as environment variable',
+    {
+        destination: 'registry.example.commy-image:latest',
+        registryMirror: 'mock-registry-mirror:5000'
+    },
+    ['registry.example.commy-image:latest'],
+    ['mock-registry-mirror:5000']
+);
+
+runTestCase(
+    'Test with invalid JSON string (fallback to string array)',
+    {
+        destination: '["registry.example.commy-image:latest"',
+        registryMirror: '["mock-registry-mirror:5000"]'
+    },
+    ['["registry.example.commy-image:latest"'], // treated as a single string in array
+    ['mock-registry-mirror:5000']
+);
+
+runTestCase(
+    'Test with no environment variables set',
+    {},
+    undefined, // Expecting undefined because no destination is set
+    undefined  // Expecting undefined because no registry mirror is set
+);

--- a/tst/testConfig.mjs
+++ b/tst/testConfig.mjs
@@ -46,12 +46,12 @@ function runTestCase(description, envVars, expectedDest, expectedMirror) {
 runTestCase(
     'Test with JSON array as environment variable',
     {
-        destination: '["registry.example.commy-image:${version}","registry.example.commy-image:latest"]',
+        destination: '["registry.example.com/my-image:${version}","registry.example.com/my-image:latest"]',
         registryMirror: '["mock-registry-mirror:5000"]'
     },
     [
-        'registry.example.commy-image:${version}',
-        'registry.example.commy-image:latest'
+        'registry.example.com/my-image:${version}',
+        'registry.example.com/my-image:latest'
     ],
     ['mock-registry-mirror:5000']
 );
@@ -59,12 +59,12 @@ runTestCase(
 runTestCase(
     'Test with comma-separated string as environment variable',
     {
-        destination: 'registry.example.commy-image:${version},registry.example.commy-image:latest',
+        destination: 'registry.example.com/my-image:${version},registry.example.com/my-image:latest',
         registryMirror: 'mock-registry-mirror:5000'
     },
     [
-        'registry.example.commy-image:${version}',
-        'registry.example.commy-image:latest'
+        'registry.example.com/my-image:${version}',
+        'registry.example.com/my-image:latest'
     ],
     ['mock-registry-mirror:5000']
 );
@@ -72,20 +72,20 @@ runTestCase(
 runTestCase(
     'Test with single string as environment variable',
     {
-        destination: 'registry.example.commy-image:latest',
+        destination: 'registry.example.com/my-image:latest',
         registryMirror: 'mock-registry-mirror:5000'
     },
-    ['registry.example.commy-image:latest'],
+    ['registry.example.com/my-image:latest'],
     ['mock-registry-mirror:5000']
 );
 
 runTestCase(
     'Test with invalid JSON string (fallback to string array)',
     {
-        destination: '["registry.example.commy-image:latest"',
+        destination: '["registry.example.com/my-image:latest"',
         registryMirror: '["mock-registry-mirror:5000"]'
     },
-    ['["registry.example.commy-image:latest"'], // treated as a single string in array
+    ['["registry.example.com/my-image:latest"'], // treated as a single string in array
     ['mock-registry-mirror:5000']
 );
 


### PR DESCRIPTION
## Issue

This fixes #16 

## Fix

I made some changes to the `parseArrayOrString` function and added a test to verify possible variants.

### Test output

```bash
--- Test with JSON array as environment variable ---
Parsed Config: {
  destination: [
    'registry.example.com/my-image:${version}',
    'registry.example.com/my-image:latest'
  ],
  registryMirror: [ 'mock-registry-mirror:5000' ]
}
Kaniko Args: [
  '--destination',
  'registry.example.com/my-image:${version}',
  '--destination',
  'registry.example.com/my-image:latest',
  '--registry-mirror',
  'mock-registry-mirror:5000'
]
Destination matched expected value
RegistryMirror matched expected value

--- Test with comma-separated string as environment variable ---
Parsed Config: {
  destination: [
    'registry.example.com/my-image:${version}',
    'registry.example.com/my-image:latest'
  ],
  registryMirror: [ 'mock-registry-mirror:5000' ]
}
Kaniko Args: [
  '--destination',
  'registry.example.com/my-image:${version}',
  '--destination',
  'registry.example.com/my-image:latest',
  '--registry-mirror',
  'mock-registry-mirror:5000'
]
Destination matched expected value
RegistryMirror matched expected value

--- Test with single string as environment variable ---
Parsed Config: {
  destination: [ 'registry.example.com/my-image:latest' ],
  registryMirror: [ 'mock-registry-mirror:5000' ]
}
Kaniko Args: [
  '--destination',
  'registry.example.com/my-image:latest',
  '--registry-mirror',
  'mock-registry-mirror:5000'
]
Destination matched expected value
RegistryMirror matched expected value

--- Test with invalid JSON string (fallback to string array) ---
Parsed Config: {
  destination: [ '["registry.example.com/my-image:latest"' ],
  registryMirror: [ 'mock-registry-mirror:5000' ]
}
Kaniko Args: [
  '--destination',
  '["registry.example.com/my-image:latest"',
  '--registry-mirror',
  'mock-registry-mirror:5000'
]
Destination matched expected value
RegistryMirror matched expected value

--- Test with no environment variables set ---
Parsed Config: {}
Kaniko Args: []
Destination matched expected value
RegistryMirror matched expected value
```
