### PR TITLE
fix: correct configuration parsing

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -1,9 +1,11 @@
-import { parseArrayOrString, toBoolean } from './utils.mjs';
+import { parseArrayOrString, toBoolean, parseString } from './utils.mjs';
 
 function parseConfig(pluginConfig) {
     const config = {};
 
-    const camelToEnvVar = (str) => 'KANIKO_' + str.split(/(?=[A-Z])/).join('_').toUpperCase();
+    const camelToEnvVar = (str) => {
+        return 'KANIKO_' + str.replace(/([a-z])([A-Z])/g, '$1_$2').toUpperCase();
+    };
 
     const parseIfDefined = (key, parser) => {
         const envVarKey = camelToEnvVar(key);
@@ -15,24 +17,24 @@ function parseConfig(pluginConfig) {
             config[key] = parser(valueFromEnv);
         }
     };
-    
+
     parseIfDefined('buildArg', JSON.parse);
     parseIfDefined('cache', toBoolean);
     parseIfDefined('cacheCopyLayers', toBoolean);
-    parseIfDefined('cacheDir', toBoolean);
-    parseIfDefined('cacheRepo', toBoolean);
+    parseIfDefined('cacheDir', parseString);
+    parseIfDefined('cacheRepo', parseString);
     parseIfDefined('cacheRunLayers', toBoolean);
-    parseIfDefined('cacheTTL', toBoolean);
+    parseIfDefined('cacheTTL', parseString);
     parseIfDefined('cleanup', toBoolean);
     parseIfDefined('compressedCaching', toBoolean);
     parseIfDefined('compression', toBoolean);
     parseIfDefined('compressionLevel', parseInt);
-    parseIfDefined('context', toBoolean);
-    parseIfDefined('contextSubPath', toBoolean);
-    parseIfDefined('customPlatform', toBoolean);
+    parseIfDefined('context', parseString);
+    parseIfDefined('contextSubPath', parseString);
+    parseIfDefined('customPlatform', parseString);
     parseIfDefined('destination', parseArrayOrString);
-    parseIfDefined('digestFile', toBoolean);
-    parseIfDefined('dockerfile', toBoolean);
+    parseIfDefined('digestFile', parseString);
+    parseIfDefined('dockerfile', parseString);
     parseIfDefined('force', toBoolean);
     parseIfDefined('forceBuildMetadata', toBoolean);
     parseIfDefined('git', JSON.parse);
@@ -40,18 +42,18 @@ function parseConfig(pluginConfig) {
     parseIfDefined('ignoreVarRun', toBoolean);
     parseIfDefined('imageDownloadRetry', parseInt);
     parseIfDefined('imageFsExtractRetry', parseInt);
-    parseIfDefined('imageNameTagWithDigestFile', toBoolean);
-    parseIfDefined('imageNameWithDigestFile', toBoolean);
+    parseIfDefined('imageNameTagWithDigestFile', parseString);
+    parseIfDefined('imageNameWithDigestFile', parseString);
     parseIfDefined('insecure', toBoolean);
     parseIfDefined('insecurePull', toBoolean);
     parseIfDefined('insecureRegistry', parseArrayOrString);
-    parseIfDefined('kanikoDir', toBoolean);
+    parseIfDefined('kanikoDir', parseString);
     parseIfDefined('label', JSON.parse);
-    parseIfDefined('logFormat', toBoolean);
+    parseIfDefined('logFormat', parseString);
     parseIfDefined('logTimestamp', toBoolean);
     parseIfDefined('noPush', toBoolean);
     parseIfDefined('noPushCache', toBoolean);
-    parseIfDefined('ociLayoutPath', toBoolean);
+    parseIfDefined('ociLayoutPath', parseString);
     parseIfDefined('pushIgnoreImmutableTagErrors', toBoolean);
     parseIfDefined('pushRetry', parseInt);
     parseIfDefined('registryCertificate', JSON.parse);
@@ -66,11 +68,11 @@ function parseConfig(pluginConfig) {
     parseIfDefined('skipTlsVerifyPull', toBoolean);
     parseIfDefined('skipTlsVerifyRegistry', parseArrayOrString);
     parseIfDefined('skipUnusedStages', toBoolean);
-    parseIfDefined('snapshotMode', toBoolean);
-    parseIfDefined('tarPath', toBoolean);
-    parseIfDefined('target', toBoolean);
+    parseIfDefined('snapshotMode', parseString);
+    parseIfDefined('tarPath', parseString);
+    parseIfDefined('target', parseString);
     parseIfDefined('useNewRun', toBoolean);
-    parseIfDefined('verbosity', toBoolean);
+    parseIfDefined('verbosity', parseString);
 
     return config;
 }
@@ -78,7 +80,7 @@ function parseConfig(pluginConfig) {
 function toKanikoArgs(config) {
     const args = [];
     if (config.buildArg) Object.entries(config.buildArg).forEach(([key, value]) => args.push('--build-arg', `${key}=${value}`));
-    if (config.cache !== undefined) args.push(`--cache=${config.cache}`);
+    if (config.cache) args.push(`--cache`);
     if (config.cacheCopyLayers) args.push('--cache-copy-layers');
     if (config.cacheDir) args.push('--cache-dir', config.cacheDir);
     if (config.cacheRepo) args.push('--cache-repo', config.cacheRepo);

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -31,3 +31,7 @@ export function parseArrayOrString(value, envVar) {
 export function toBoolean(value) {
     return value === true || value === 'true';
 }
+
+export function parseString(value) {
+    return value.toString();
+}

--- a/tst/testConfig2.mjs
+++ b/tst/testConfig2.mjs
@@ -1,0 +1,76 @@
+import { parseConfig, toKanikoArgs } from '../lib/config.mjs';
+
+// Function to run a test case
+function runTestCase(description, envVars, expectedCache, expectedCacheTTL, expectedDir, expectedTarget) {
+    console.log(`\n--- ${description} ---`);
+
+    // Clear environment variables before each test
+    delete process.env.KANIKO_CACHE;
+    delete process.env.KANIKO_CACHE_TTL;
+    delete process.env.KANIKO_KANIKO_DIR;
+    delete process.env.KANIKO_TARGET;
+
+    // Set environment variables for the test
+    if (envVars.cache) {
+        process.env.KANIKO_CACHE = envVars.cache;
+    }
+    if (envVars.cacheTTL) {
+        process.env.KANIKO_CACHE_TTL = envVars.cacheTTL;
+    }
+    if (envVars.kanikoDir) {
+        process.env.KANIKO_KANIKO_DIR = envVars.kanikoDir;
+    }
+    if (envVars.target) {
+        process.env.KANIKO_TARGET = envVars.target;
+    }
+
+    // Mock plugin configuration object
+    const pluginConfig = {};
+
+    // Parse configuration
+    const config = parseConfig(pluginConfig);
+
+    // Convert parsed config to Kaniko args
+    const kanikoArgs = toKanikoArgs(config);
+
+    // Output the results
+    console.log('Parsed Config:', config);
+    console.log('Kaniko Args:', kanikoArgs);
+
+    // Assertions (could be replaced with an actual testing framework)
+    if (config.cache !== expectedCache) {
+        console.error('Test failed: cache did not match expected value');
+    } else {
+        console.log('Cache matched expected value');
+    }
+    if (config.cacheTTL !== expectedCacheTTL) {
+        console.error('Test failed: cacheTTL did not match expected value');
+    } else {
+        console.log('cacheTTL matched expected value');
+    }
+    if (config.kanikoDir !== expectedDir) {
+        console.error('Test failed: kanikoDir did not match expected value');
+    } else {
+        console.log('kanikoDir matched expected value');
+    }
+    if (config.target !== expectedTarget) {
+        console.error('Test failed: target did not match expected value');
+    } else {
+        console.log('Target matched expected value');
+    }
+}
+
+// New Test Case
+runTestCase(
+    'Test with cache, cacheTTL, and dir environment variables',
+    {
+        cache: 'true',
+        cacheTTL: '48h',
+        kanikoDir: '/tmp/kaniko',
+        target: 'foo'
+    },
+    true,
+    '48h',
+    '/tmp/kaniko',
+    'foo'
+);


### PR DESCRIPTION
I found two issues in the configuration parser:

* 18 parameters were not treated as a string but as a boolean. This resulted in neither of these parameters ending up in the arguments passed to Kaniko. I changed them to a string instead.
* The `camelToEnvVar` function caused the `KANIKO_CACHE_TTL` to become `KANIKO_CACHE_T_T_L`. Changed the logic to handle this better.

## Test output

```bash
--- Test with cache, cacheTTL, and dir environment variables ---
Parsed Config: {
  cache: true,
  cacheTTL: '48h',
  kanikoDir: '/tmp/kaniko',
  target: 'foo'
}
Kaniko Args: [
  '--cache',
  '--cache-ttl',
  '48h',
  '--kaniko-dir',
  '/tmp/kaniko',
  '--target',
  'foo'
]
Cache matched expected value
cacheTTL matched expected value
kanikoDir matched expected value
Target matched expected value

```